### PR TITLE
Offer prompt for formatted description

### DIFF
--- a/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
+++ b/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
@@ -27,13 +27,13 @@ public final class OfferFormattedDescriptionPromptConstants {
     public static final String JSON_SCHEMA = """
         {
           "description": "string - The job description text",
-          "mainTech": "string - Primary technology stack or focus, e.g., 'Java,ADVANCED'",
-          "skills": "string - Comma-separated skills with levels, e.g., 'Java,ADVANCED - Spring Boot,INTERMEDIATE'",
+          "mainTech": "string - Primary technology stack or focus, e.g., 'Full stack Java SpringBoot'",
+          "skills": "string - Offer required skills separated by ' - ' e.g., 'Java - Spring Boot - Docker'",
           "languages": "array of objects - [{'languageName': 'English', 'level': 'ADVANCED'}]",
-          "yearsOfExperience": "integer - Minimum years of experience",
-          "mainResponsibilities": "string - Core tasks separated by ' - '",
-          "education": "string - Education requirements separated by ' - '",
-          "keywords": "string - Key terms separated by ' - '"
+          "yearsOfExperience": "integer - Minimum required years of experience",
+          "mainResponsibilities": "string - offer tasks separated by ' - '",
+          "education": "string - Education requirements",
+          "keywords": "string - Offer Keywords separated by ' - '"
         }
         """;
 

--- a/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
+++ b/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
@@ -1,0 +1,155 @@
+package ma.nttdata.externals.commons.constants;
+
+public final class OfferFormattedDescriptionPromptConstants {
+
+    private OfferFormattedDescriptionPromptConstants() {}
+
+        public static final String OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT = """
+            You are an expert HR data extraction specialist. Your task is to extract key information from job offer descriptions to create structured candidate profiles for our interview system.
+            
+            Extract the following information from the provided job offer description:
+            
+            FIELDS TO EXTRACT:
+            - about: Extract ONLY essential requirements (nationality, visa status, security clearance, location constraints, travel requirements). Ignore generic company descriptions and marketing content.
+            - skills: Technical and professional skills required with proficiency levels (programming languages, frameworks, tools, certifications, soft skills)
+            - languages: Required languages with proficiency levels (native, fluent, conversational, basic)
+            - yearsOfExperience: Minimum and/or preferred years of experience (handle ranges like "3-5 years" or "5+ years")
+            - mainResponsibilities: Core day-to-day tasks and duties the candidate will perform (focus on actionable responsibilities, not job titles)
+            - education: Required degree level and field of study (both are important for matching)
+            - keywords: Key terms from job title, critical skills, and industry-specific terminology that don't fit in other categories
+            
+            EXTRACTION GUIDELINES:
+            - Be concise and precise in your extractions
+            - For skills: Include proficiency levels when specified (expert, advanced, intermediate, basic) or requirements level (required, preferred)
+            - For education: Capture both level (Bachelor's, Master's, etc.) and field (Computer Science, Engineering, etc.)
+            - For experience: Extract both minimum requirements and preferred levels if mentioned
+            - For responsibilities: Focus on what the person will actually do, not company goals
+            - For about: Only include information relevant to candidate eligibility and requirements
+            - For keywords: Include terms that are crucial for candidate matching but don't fit other categories
+            
+            Return ONLY a valid JSON object with exactly this structure, no additional text or formatting: "{JSON_SCHEMA}"
+            
+            Here is an example of the expected output: "{JSON_MOCK}"
+            
+            Job Offer Description to extract from: "{OFFER_DESCRIPTION}"
+            """;
+
+        public static final String JSON_SCHEMA = """
+            {
+              "about": "string - Essential requirements only (nationality, visa, location, clearance, travel)",
+              "skills": "array of objects - [{'skill': 'Java', 'level': 'advanced', 'required': true}]",
+              "languages": "array of objects - [{'language': 'English', 'level': 'fluent'}]",
+              "yearsOfExperience": "string - Experience requirements (e.g., '3-5 years', '5+ years')",
+              "mainResponsibilities": "array of strings - Core tasks and duties",
+              "education": "array of objects - [{'level': 'Bachelor's', 'field': 'Computer Science', 'required': true}]",
+              "keywords": "array of strings - Key terms for matching not covered in other fields"
+            }
+            """;
+
+        public static final String JSON_MOCK = """
+            {
+              "about": "EU citizenship required, willing to travel 25% of the time, security clearance preferred",
+              "skills": [
+                {
+                  "skill": "Java",
+                  "level": "advanced",
+                  "required": true
+                },
+                {
+                  "skill": "Spring Boot",
+                  "level": "intermediate",
+                  "required": true
+                },
+                {
+                  "skill": "Microservices",
+                  "level": "advanced",
+                  "required": true
+                },
+                {
+                  "skill": "Docker",
+                  "level": "intermediate",
+                  "required": false
+                },
+                {
+                  "skill": "Kubernetes",
+                  "level": "basic",
+                  "required": false
+                },
+                {
+                  "skill": "AWS",
+                  "level": "intermediate",
+                  "required": true
+                },
+                {
+                  "skill": "MySQL",
+                  "level": "intermediate",
+                  "required": true
+                },
+                {
+                  "skill": "Team leadership",
+                  "level": "advanced",
+                  "required": true
+                },
+                {
+                  "skill": "Problem solving",
+                  "level": "advanced",
+                  "required": true
+                },
+                {
+                  "skill": "Communication",
+                  "level": "advanced",
+                  "required": true
+                }
+              ],
+              "languages": [
+                {
+                  "language": "English",
+                  "level": "fluent"
+                },
+                {
+                  "language": "French",
+                  "level": "conversational"
+                }
+              ],
+              "yearsOfExperience": "5+ years in backend development, 2+ years in team leadership",
+              "mainResponsibilities": [
+                "Design and develop microservices architecture",
+                "Lead a team of 4-6 developers",
+                "Conduct code reviews and technical discussions",
+                "Collaborate with product managers on requirements",
+                "Mentor junior developers",
+                "Optimize application performance and scalability",
+                "Implement CI/CD pipelines",
+                "Participate in on-call rotation"
+              ],
+              "education": [
+              {
+                "level": "Bachelor's",
+                "field": "Computer Science or Engineering",
+                "required": true
+              },
+              {
+                "level": "Master's",
+                "field": "Computer Science",
+                "required": true
+              }
+              ],
+              "keywords": [
+                "Senior Backend Developer",
+                "Team Lead",
+                "Fintech",
+                "Agile",
+                "Scrum Master",
+                "API Design",
+                "DevOps"
+              ]
+            }
+            """;
+
+        public static final String OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT_CODE = "OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT";
+        public static final String OFFER_DESCRIPTION_PLACEHOLDER = "{OFFER_DESCRIPTION}";
+        public static final String JSON_SCHEMA_PLACEHOLDER = "{JSON_SCHEMA}";
+        public static final String JSON_MOCK_PLACEHOLDER = "{JSON_MOCK}";
+
+
+}

--- a/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
+++ b/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
@@ -4,152 +4,58 @@ public final class OfferFormattedDescriptionPromptConstants {
 
     private OfferFormattedDescriptionPromptConstants() {}
 
-        public static final String OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT = """
-            You are an expert HR data extraction specialist. Your task is to extract key information from job offer descriptions to create structured candidate profiles for our interview system.
-            
-            Extract the following information from the provided job offer description:
-            
-            FIELDS TO EXTRACT:
-            - about: Extract ONLY essential requirements (nationality, visa status, security clearance, location constraints, travel requirements). Ignore generic company descriptions and marketing content.
-            - skills: Technical and professional skills required with proficiency levels (programming languages, frameworks, tools, certifications, soft skills)
-            - languages: Required languages with proficiency levels (native, fluent, conversational, basic)
-            - yearsOfExperience: Minimum and/or preferred years of experience (handle ranges like "3-5 years" or "5+ years")
-            - mainResponsibilities: Core day-to-day tasks and duties the candidate will perform (focus on actionable responsibilities, not job titles)
-            - education: Required degree level and field of study (both are important for matching)
-            - keywords: Key terms from job title, critical skills, and industry-specific terminology that don't fit in other categories
-            
-            EXTRACTION GUIDELINES:
-            - Be concise and precise in your extractions
-            - For skills: Include proficiency levels when specified (expert, advanced, intermediate, basic) or requirements level (required, preferred)
-            - For education: Capture both level (Bachelor's, Master's, etc.) and field (Computer Science, Engineering, etc.)
-            - For experience: Extract both minimum requirements and preferred levels if mentioned
-            - For responsibilities: Focus on what the person will actually do, not company goals
-            - For about: Only include information relevant to candidate eligibility and requirements
-            - For keywords: Include terms that are crucial for candidate matching but don't fit other categories
-            
-            Return ONLY a valid JSON object with exactly this structure, no additional text or formatting: "{JSON_SCHEMA}"
-            
-            Here is an example of the expected output: "{JSON_MOCK}"
-            
-            Job Offer Description to extract from: "{OFFER_DESCRIPTION}"
-            """;
+    public static final String OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT = """
+        You are an expert HR data extraction specialist. Your task is to extract key information from job offer descriptions to create structured, formatted data for frontend display in our interview system.
+        I will give you the the information for the #offerDescription, #JSON_MOCK an example of the data we want and #JSON_SCHEMA you should respect when extracting information.                                 
+        Take these instructions into consideration:
+        - description: The main job description and company information (keep the original descriptive content for display)
+        - mainTech: The primary technology stack or focus of the job, formatted like skills (format: "Tech,Level"), e.g., "Java,ADVANCED"
+        - skills: Technical and professional skills required with proficiency levels (format: "Skill,Level - Skill,Level"), e.g., "Java,ADVANCED - Spring Boot,INTERMEDIATE - Docker,BEGINNER"
+        - languages: Required languages with proficiency levels converted to enum values using mapping: A1, A2, Basic, Elementary → BEGINNER; B1, Lower Intermediate → LOWER_INTERMEDIATE; B2, Intermediate → INTERMEDIATE; C1, Upper Intermediate → UPPER_INTERMEDIATE; C2, Advanced, Fluent, Native → ADVANCED, and for the names of languages they should be in english.
+        - yearsOfExperience: Minimum years of experience (from "3-5 years" extract 3, from "5+ years" extract 5)
+        - mainResponsibilities: Core day-to-day tasks and duties the candidate will perform, separated by " - "
+        - education: Required degree level and field of study, separated by " - "
+        - keywords: Key terms from job title, critical skills, and industry-specific terminology that don't fit in other categories
 
-        public static final String JSON_SCHEMA = """
-            {
-              "about": "string - Essential requirements only (nationality, visa, location, clearance, travel)",
-              "skills": "array of objects - [{'skill': 'Java', 'level': 'advanced', 'required': true}]",
-              "languages": "array of objects - [{'language': 'English', 'level': 'fluent'}]",
-              "yearsOfExperience": "string - Experience requirements (e.g., '3-5 years', '5+ years')",
-              "mainResponsibilities": "array of strings - Core tasks and duties",
-              "education": "array of objects - [{'level': 'Bachelor's', 'field': 'Computer Science', 'required': true}]",
-              "keywords": "array of strings - Key terms for matching not covered in other fields"
-            }
-            """;
+        Return ONLY a valid JSON object with exactly this structure, no additional text or formatting: "{JSON_SCHEMA}"
 
-        public static final String JSON_MOCK = """
-            {
-              "about": "EU citizenship required, willing to travel 25% of the time, security clearance preferred",
-              "skills": [
-                {
-                  "skill": "Java",
-                  "level": "advanced",
-                  "required": true
-                },
-                {
-                  "skill": "Spring Boot",
-                  "level": "intermediate",
-                  "required": true
-                },
-                {
-                  "skill": "Microservices",
-                  "level": "advanced",
-                  "required": true
-                },
-                {
-                  "skill": "Docker",
-                  "level": "intermediate",
-                  "required": false
-                },
-                {
-                  "skill": "Kubernetes",
-                  "level": "basic",
-                  "required": false
-                },
-                {
-                  "skill": "AWS",
-                  "level": "intermediate",
-                  "required": true
-                },
-                {
-                  "skill": "MySQL",
-                  "level": "intermediate",
-                  "required": true
-                },
-                {
-                  "skill": "Team leadership",
-                  "level": "advanced",
-                  "required": true
-                },
-                {
-                  "skill": "Problem solving",
-                  "level": "advanced",
-                  "required": true
-                },
-                {
-                  "skill": "Communication",
-                  "level": "advanced",
-                  "required": true
-                }
-              ],
-              "languages": [
-                {
-                  "language": "English",
-                  "level": "fluent"
-                },
-                {
-                  "language": "French",
-                  "level": "conversational"
-                }
-              ],
-              "yearsOfExperience": "5+ years in backend development, 2+ years in team leadership",
-              "mainResponsibilities": [
-                "Design and develop microservices architecture",
-                "Lead a team of 4-6 developers",
-                "Conduct code reviews and technical discussions",
-                "Collaborate with product managers on requirements",
-                "Mentor junior developers",
-                "Optimize application performance and scalability",
-                "Implement CI/CD pipelines",
-                "Participate in on-call rotation"
-              ],
-              "education": [
-              {
-                "level": "Bachelor's",
-                "field": "Computer Science or Engineering",
-                "required": true
-              },
-              {
-                "level": "Master's",
-                "field": "Computer Science",
-                "required": true
-              }
-              ],
-              "keywords": [
-                "Senior Backend Developer",
-                "Team Lead",
-                "Fintech",
-                "Agile",
-                "Scrum Master",
-                "API Design",
-                "DevOps"
-              ]
-            }
-            """;
+        Here is an example of the expected output: "{JSON_MOCK}"
 
-        public static final String OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT_CODE = "OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT";
-        public static final String OFFER_DESCRIPTION_PLACEHOLDER = "{OFFER_DESCRIPTION}";
-        public static final String JSON_SCHEMA_PLACEHOLDER = "{JSON_SCHEMA}";
-        public static final String JSON_MOCK_PLACEHOLDER = "{JSON_MOCK}";
+        Job Offer Description to extract from: "{OFFER_DESCRIPTION}"
+        """;
 
+    public static final String JSON_SCHEMA = """
+        {
+          "description": "string - The job description text",
+          "mainTech": "string - Primary technology stack or focus, e.g., 'Java,ADVANCED'",
+          "skills": "string - Comma-separated skills with levels, e.g., 'Java,ADVANCED - Spring Boot,INTERMEDIATE'",
+          "languages": "array of objects - [{'language': 'English', 'level': 'ADVANCED'}]",
+          "yearsOfExperience": "integer - Minimum years of experience",
+          "mainResponsibilities": "string - Core tasks separated by ' - '",
+          "education": "string - Education requirements separated by ' - '",
+          "keywords": "string - Key terms separated by ' - '"
+        }
+        """;
+
+    public static final String JSON_MOCK = """
+        {
+          "description": "We are seeking a highly skilled Senior Java Developer to join our dynamic fintech team. The role involves designing and implementing scalable microservices, collaborating with cross-functional teams, and ensuring high-quality code standards. The candidate will contribute to architecture decisions, mentor junior developers, and help drive the adoption of best practices.",
+          "mainTech": "Java,ADVANCED",
+          "skills": "Java,ADVANCED - Spring Boot,ADVANCED - Docker,INTERMEDIATE - Kubernetes,INTERMEDIATE - AWS,INTERMEDIATE - MySQL,ADVANCED - Git,ADVANCED - Agile,INTERMEDIATE - Team Leadership,ADVANCED - Communication,ADVANCED",
+          "languages": [
+            {"language": "English", "level": "ADVANCED"},
+            {"language": "French", "level": "INTERMEDIATE"}
+          ],
+          "yearsOfExperience": 6,
+          "mainResponsibilities": "Design and implement microservices architecture - Optimize application performance - Maintain CI/CD pipelines - Conduct code reviews and mentor junior developers - Collaborate with product managers and QA team - Participate in on-call rotation",
+          "education": "Bachelor in Computer Science - Master in Software Engineering",
+          "keywords": "Java - Spring Boot - Microservices - Docker - Kubernetes - Fintech - Agile - DevOps - AWS - Backend Development"
+        }
+        """;
+
+    public static final String OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT_CODE = "OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT";
+    public static final String OFFER_DESCRIPTION_PLACEHOLDER = "{OFFER_DESCRIPTION}";
+    public static final String JSON_SCHEMA_PLACEHOLDER = "{JSON_SCHEMA}";
+    public static final String JSON_MOCK_PLACEHOLDER = "{JSON_MOCK}";
 
 }

--- a/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
+++ b/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
@@ -5,24 +5,21 @@ public final class OfferFormattedDescriptionPromptConstants {
     private OfferFormattedDescriptionPromptConstants() {}
 
     public static final String OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT = """
-        You are an expert HR data extraction specialist. Your task is to extract key information from job offer descriptions to create structured, formatted data for frontend display in our interview system.
-        I will give you the the information for the #offerDescription, #JSON_MOCK an example of the data we want and #JSON_SCHEMA you should respect when extracting information.                                 
-        Take these instructions into consideration:
-        - description: The main job description and company information (keep the original descriptive content for display)
-        - mainTech: The primary technology stack or focus of the job, formatted like skills (format: "Tech,Level"), e.g., "Java,ADVANCED"
-        - skills: Technical and professional skills required with proficiency levels (format: "Skill,Level - Skill,Level"), e.g., "Java,ADVANCED - Spring Boot,INTERMEDIATE - Docker,BEGINNER"
-        - languages: Required languages with proficiency levels converted to enum values using mapping: A1, A2, Basic, Elementary → BEGINNER; B1, Lower Intermediate → LOWER_INTERMEDIATE; B2, Intermediate → INTERMEDIATE; C1, Upper Intermediate → UPPER_INTERMEDIATE; C2, Advanced, Fluent, Native → ADVANCED, and for the names of languages they should be in english.
-        - yearsOfExperience: Minimum years of experience (from "3-5 years" extract 3, from "5+ years" extract 5)
-        - mainResponsibilities: Core day-to-day tasks and duties the candidate will perform, separated by " - "
-        - education: Required degree level and field of study, separated by " - "
-        - keywords: Key terms from job title, critical skills, and industry-specific terminology that don't fit in other categories
-
-        Return ONLY a valid JSON object with exactly this structure, no additional text or formatting: "{JSON_SCHEMA}"
-
-        Here is an example of the expected output: "{JSON_MOCK}"
-
-        Job Offer Description to extract from: "{OFFER_DESCRIPTION}"
-        """;
+            You are an expert HR data extraction specialist.
+             I will give you an #Offer_Description, Extract the key information from it, and return a structured, formatted Json like provided in #JSON_SCHEMA, when extracting information, respect the schema we want an exact match, we'll provide also a and #JSON_MOCK to help with that.
+            Take these instructions into consideration:
+            -For all the fields, keep the original text from the provided description just extract from it what matches the criteria.
+            -description: The main offer description and company information (keep the original text from the provided description just extract from it).
+            - skills: The required technical and professional skills.
+             - languages: The required language names and the proficiency levels. the names should be in English, the proficiency level should be one of these words: [BEGINNER, LOWER_INTERMEDIATE ,INTERMEDIATE, UPPER_INTERMEDIATE, ADVANCED], it might not be present in the description with the exact name, detect the required language level, and convert it accordignly to one of these values.
+             - yearsOfExperience: The required years of experience in the offer description (from "3-5 years" extract 3, from "5+ years" extract 5).
+             - mainResponsibilities: The tasks and duties mentioned in the offer description, that the candidate will perform if he got accepted in the offer.
+             - education: The required education from the offer description.
+             - keywords: The keywords of the offer description.
+             Return only a valid JSON object with exactly this structure, no additional text or formatting,  #JSON_SCHEMA structure: "{JSON_SCHEMA}"
+             Here is an example of the expected output, #JSON_MOCK structure: "{JSON_MOCK}"
+             #Offer_Description: "{OFFER_DESCRIPTION}
+            """;
 
     public static final String JSON_SCHEMA = """
         {

--- a/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
+++ b/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
@@ -8,9 +8,9 @@ public final class OfferFormattedDescriptionPromptConstants {
             You are an expert HR data extraction specialist.
              I will give you an #Offer_Description, Extract the key information from it, and return a structured, formatted Json like provided in #JSON_SCHEMA, when extracting information, respect the schema we want an exact match, we'll provide also a and #JSON_MOCK to help with that.
             Take these instructions into consideration:
-            -For all the fields, keep the original text from the provided description just extract from it what matches the criteria.
-            -description: The main offer description and company information (keep the original text from the provided description just extract from it).
-            - skills: The required technical and professional skills.
+             -For all the fields, keep the original text from the provided description just extract from it what matches the criteria.
+             -description: The main offer description and company information (keep the original text from the provided description just extract from it).
+             - skills: The required technical and professional skills.
              - languages: The required language names and the proficiency levels. the names should be in English, the proficiency level should be one of these words: [BEGINNER, LOWER_INTERMEDIATE ,INTERMEDIATE, UPPER_INTERMEDIATE, ADVANCED], it might not be present in the description with the exact name, detect the required language level, and convert it accordignly to one of these values.
              - yearsOfExperience: The required years of experience in the offer description (from "3-5 years" extract 3, from "5+ years" extract 5).
              - mainResponsibilities: The tasks and duties mentioned in the offer description, that the candidate will perform if he got accepted in the offer.
@@ -23,13 +23,13 @@ public final class OfferFormattedDescriptionPromptConstants {
 
     public static final String JSON_SCHEMA = """
         {
-          "description": "string - The job description text",
+          "description": "string ",
           "mainTech": "string - Primary technology stack or focus, e.g., 'Full stack Java SpringBoot'",
           "skills": "string - Offer required skills separated by ' - ' e.g., 'Java - Spring Boot - Docker'",
           "languages": "array of objects - [{'languageName': 'English', 'level': 'ADVANCED'}]",
           "yearsOfExperience": "integer - Minimum required years of experience",
           "mainResponsibilities": "string - offer tasks separated by ' - '",
-          "education": "string - Education requirements",
+          "education": "string - Education requirements separated by ' - '",
           "keywords": "string - Offer Keywords separated by ' - '"
         }
         """;

--- a/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
+++ b/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
@@ -29,7 +29,7 @@ public final class OfferFormattedDescriptionPromptConstants {
           "description": "string - The job description text",
           "mainTech": "string - Primary technology stack or focus, e.g., 'Java,ADVANCED'",
           "skills": "string - Comma-separated skills with levels, e.g., 'Java,ADVANCED - Spring Boot,INTERMEDIATE'",
-          "languages": "array of objects - [{'language': 'English', 'level': 'ADVANCED'}]",
+          "languages": "array of objects - [{'languageName': 'English', 'level': 'ADVANCED'}]",
           "yearsOfExperience": "integer - Minimum years of experience",
           "mainResponsibilities": "string - Core tasks separated by ' - '",
           "education": "string - Education requirements separated by ' - '",
@@ -43,8 +43,8 @@ public final class OfferFormattedDescriptionPromptConstants {
           "mainTech": "Java,ADVANCED",
           "skills": "Java,ADVANCED - Spring Boot,ADVANCED - Docker,INTERMEDIATE - Kubernetes,INTERMEDIATE - AWS,INTERMEDIATE - MySQL,ADVANCED - Git,ADVANCED - Agile,INTERMEDIATE - Team Leadership,ADVANCED - Communication,ADVANCED",
           "languages": [
-            {"language": "English", "level": "ADVANCED"},
-            {"language": "French", "level": "INTERMEDIATE"}
+            {"languageName": "English", "level": "ADVANCED"},
+            {"languageName": "French", "level": "INTERMEDIATE"}
           ],
           "yearsOfExperience": 6,
           "mainResponsibilities": "Design and implement microservices architecture - Optimize application performance - Maintain CI/CD pipelines - Conduct code reviews and mentor junior developers - Collaborate with product managers and QA team - Participate in on-call rotation",

--- a/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
+++ b/src/main/java/ma/nttdata/externals/commons/constants/OfferFormattedDescriptionPromptConstants.java
@@ -37,8 +37,8 @@ public final class OfferFormattedDescriptionPromptConstants {
     public static final String JSON_MOCK = """
         {
           "description": "We are seeking a highly skilled Senior Java Developer to join our dynamic fintech team. The role involves designing and implementing scalable microservices, collaborating with cross-functional teams, and ensuring high-quality code standards. The candidate will contribute to architecture decisions, mentor junior developers, and help drive the adoption of best practices.",
-          "mainTech": "Java,ADVANCED",
-          "skills": "Java,ADVANCED - Spring Boot,ADVANCED - Docker,INTERMEDIATE - Kubernetes,INTERMEDIATE - AWS,INTERMEDIATE - MySQL,ADVANCED - Git,ADVANCED - Agile,INTERMEDIATE - Team Leadership,ADVANCED - Communication,ADVANCED",
+          "mainTech": "Full Stack Javascript",
+          "skills": "Java - Spring Boot - Docker - Kubernetes - AWS - MySQL - Git - Agile - Team Leadership - Communication",
           "languages": [
             {"languageName": "English", "level": "ADVANCED"},
             {"languageName": "French", "level": "INTERMEDIATE"}

--- a/src/main/java/ma/nttdata/externals/module/candidate/dto/OfferFormattedDescriptionLanguageDTO.java
+++ b/src/main/java/ma/nttdata/externals/module/candidate/dto/OfferFormattedDescriptionLanguageDTO.java
@@ -1,0 +1,9 @@
+package ma.nttdata.externals.module.candidate.dto;
+
+import ma.nttdata.externals.module.candidate.constants.LanguageLevel;
+
+public record OfferFormattedDescriptionLanguageDTO(
+        String languageName,
+        LanguageLevel level
+) {
+}

--- a/src/main/java/ma/nttdata/externals/module/interview/entity/Interview.java
+++ b/src/main/java/ma/nttdata/externals/module/interview/entity/Interview.java
@@ -3,6 +3,7 @@ package ma.nttdata.externals.module.interview.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import ma.nttdata.externals.module.candidate.entity.Candidate;
 import ma.nttdata.externals.module.offer.entity.Offer;
 
@@ -13,7 +14,7 @@ import java.util.UUID;
 @Entity
 @Table(name = "interviews")
 @Getter
-@Setter
+@Setter@ToString
 public class Interview {
     @Id
     @GeneratedValue

--- a/src/main/java/ma/nttdata/externals/module/offer/controller/OfferController.java
+++ b/src/main/java/ma/nttdata/externals/module/offer/controller/OfferController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import ma.nttdata.externals.module.offer.dto.OfferDTO;
+import ma.nttdata.externals.module.offer.dto.OfferFormattedDescriptionDTO;
 import ma.nttdata.externals.module.offer.service.OfferServ;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -99,5 +100,33 @@ public class OfferController {
         List<String> titles = offerServ.getDistinctTitles();
         return ResponseEntity.ok(titles);
     }
+
+    @PostMapping("/{id}/prepare-formatted-description")
+    @Operation(summary = "Prepare formatted description for an offer",
+            description = "Generates a structured and formatted description for a specific job offer using AI and saves it.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Formatted description generated successfully",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = OfferFormattedDescriptionDTO.class))),
+            @ApiResponse(responseCode = "404", description = "Offer not found"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    public ResponseEntity<OfferFormattedDescriptionDTO> prepareFormattedDescription(@PathVariable UUID id) {
+        OfferFormattedDescriptionDTO formattedDescriptionDTO = offerServ.prepareFormattedDescriptionByPrompt(id);
+        return ResponseEntity.ok(formattedDescriptionDTO);
+    }
+
+    @GetMapping("/{id}/formatted-description")
+    @Operation(summary = "Get formatted description for an offer",
+            description = "Retrieves the previously generated formatted description of a specific job offer.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Formatted description retrieved successfully",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = OfferFormattedDescriptionDTO.class))),
+            @ApiResponse(responseCode = "404", description = "Offer not found")
+    })
+    public ResponseEntity<OfferFormattedDescriptionDTO> getFormattedDescription(@PathVariable UUID id) {
+        OfferFormattedDescriptionDTO formattedDescriptionDTO = offerServ.getFormattedDescription(id);
+        return ResponseEntity.ok(formattedDescriptionDTO);
+    }
+
 
 }

--- a/src/main/java/ma/nttdata/externals/module/offer/dto/OfferDTO.java
+++ b/src/main/java/ma/nttdata/externals/module/offer/dto/OfferDTO.java
@@ -1,5 +1,6 @@
 package ma.nttdata.externals.module.offer.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import ma.nttdata.externals.module.interview.dto.InterviewDTO;
 
 import java.util.List;
@@ -9,6 +10,8 @@ public record OfferDTO(
         UUID id,
         String title,
         String description ,
+        @JsonProperty(defaultValue = "null")
+        String formattedDescription,
         List<InterviewDTO> interviews
 
 ) {}

--- a/src/main/java/ma/nttdata/externals/module/offer/dto/OfferFormattedDescriptionDTO.java
+++ b/src/main/java/ma/nttdata/externals/module/offer/dto/OfferFormattedDescriptionDTO.java
@@ -1,0 +1,17 @@
+package ma.nttdata.externals.module.offer.dto;
+
+import ma.nttdata.externals.module.candidate.dto.OfferFormattedDescriptionLanguageDTO;
+
+import java.util.List;
+
+public record OfferFormattedDescriptionDTO(
+        String description,
+        String mainTech,
+        String skills,
+        List<OfferFormattedDescriptionLanguageDTO> languages,
+        int yearsOfExperience,
+        String mainResponsibilities,
+        String education,
+        String keywords
+) {
+}

--- a/src/main/java/ma/nttdata/externals/module/offer/entity/Offer.java
+++ b/src/main/java/ma/nttdata/externals/module/offer/entity/Offer.java
@@ -25,6 +25,9 @@ public class Offer {
     @Column(columnDefinition = "TEXT")
     private String description;
 
+    @Column(name = "formatted_description")
+    String formattedDescription;
+
     // offer have many inter
     @OneToMany(mappedBy = "offer", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Interview> interviews;

--- a/src/main/java/ma/nttdata/externals/module/offer/mapper/OfferMapper.java
+++ b/src/main/java/ma/nttdata/externals/module/offer/mapper/OfferMapper.java
@@ -23,7 +23,6 @@ public interface OfferMapper {
     @Mapping(target = "id", source = "id")
     OfferDTO toDto(Offer offer);
 
-
     // to entity
     @Mapping(target = "title", source = "title")
     @Mapping(target = "description", source = "description")

--- a/src/main/java/ma/nttdata/externals/module/offer/mapper/OfferMapper.java
+++ b/src/main/java/ma/nttdata/externals/module/offer/mapper/OfferMapper.java
@@ -1,6 +1,10 @@
 package ma.nttdata.externals.module.offer.mapper;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ma.nttdata.externals.commons.exception.InternalServerException;
 import ma.nttdata.externals.module.offer.dto.OfferDTO;
+import ma.nttdata.externals.module.offer.dto.OfferFormattedDescriptionDTO;
 import ma.nttdata.externals.module.offer.entity.Offer;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -29,4 +33,18 @@ public interface OfferMapper {
     List<OfferDTO> toDtoList(List<Offer> offers);
 
     List<Offer> toEntityList(List<OfferDTO> offerDTOs);
+
+    default OfferFormattedDescriptionDTO mapJsonToDTO(String json){
+        if (json == null || json.isEmpty()) {
+            return null;
+        }
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try{
+            return objectMapper.readValue(json,OfferFormattedDescriptionDTO.class);
+        }catch(JsonProcessingException e){
+            throw new InternalServerException("Failed to parse questions JSON", e);
+        }
+    }
 }

--- a/src/main/java/ma/nttdata/externals/module/offer/repository/OfferRepository.java
+++ b/src/main/java/ma/nttdata/externals/module/offer/repository/OfferRepository.java
@@ -2,7 +2,9 @@ package ma.nttdata.externals.module.offer.repository;
 
 import ma.nttdata.externals.module.offer.entity.Offer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.UUID;
@@ -11,4 +13,8 @@ public interface OfferRepository extends JpaRepository<Offer, UUID> {
 
     @Query("SELECT DISTINCT o.title FROM Offer o")
     List<String> findDistinctTitles();
+
+    @Modifying
+    @Query("UPDATE Offer o SET o.formattedDescription = :formattedDescription WHERE o.id = :offerId")
+    int updateFormattedDescriptionById(@Param("offerId") UUID offerId, @Param("formattedDescription") String formattedDescription);
 }

--- a/src/main/java/ma/nttdata/externals/module/offer/service/OfferServ.java
+++ b/src/main/java/ma/nttdata/externals/module/offer/service/OfferServ.java
@@ -1,6 +1,8 @@
 package ma.nttdata.externals.module.offer.service;
 
 import ma.nttdata.externals.module.offer.dto.OfferDTO;
+import ma.nttdata.externals.module.offer.dto.OfferFormattedDescriptionDTO;
+import ma.nttdata.externals.module.prompt.dto.PromptDTO;
 
 import java.util.List;
 import java.util.UUID;
@@ -19,4 +21,9 @@ public interface OfferServ {
 
     List<String> getDistinctTitles();
 
+    String getOfferFormattedDescriptionFromAIByPrompt(PromptDTO prompt,String offerDescription);
+
+    OfferFormattedDescriptionDTO prepareFormattedDescriptionByPrompt(UUID offerID);
+
+    OfferFormattedDescriptionDTO getFormattedDescription(UUID OfferId);
 }

--- a/src/main/java/ma/nttdata/externals/module/offer/service/OfferServ.java
+++ b/src/main/java/ma/nttdata/externals/module/offer/service/OfferServ.java
@@ -26,4 +26,6 @@ public interface OfferServ {
     OfferFormattedDescriptionDTO prepareFormattedDescriptionByPrompt(UUID offerID);
 
     OfferFormattedDescriptionDTO getFormattedDescription(UUID OfferId);
+
+    int setFormattedDescription(UUID offerID, String formattedDescription);
 }

--- a/src/main/java/ma/nttdata/externals/module/offer/service/impl/OfferServImpl.java
+++ b/src/main/java/ma/nttdata/externals/module/offer/service/impl/OfferServImpl.java
@@ -40,6 +40,7 @@ public class OfferServImpl implements OfferServ {
         this.promptService = promptService;
     }
 
+
     // create srv
     @Override
     public OfferDTO createOffer(OfferDTO offerDTO) {
@@ -52,6 +53,7 @@ public class OfferServImpl implements OfferServ {
     public OfferDTO getOfferById(UUID id) {
         Offer offer = offerRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Offer not found with id: " + id));
+        System.out.println("Offer : "+offer);
         return offerMapper.toDto(offer);
     }
 
@@ -104,17 +106,19 @@ public class OfferServImpl implements OfferServ {
     public OfferFormattedDescriptionDTO prepareFormattedDescriptionByPrompt(UUID offerID){
         PromptDTO prompt = promptService.findByPromptCode(OfferFormattedDescriptionPromptConstants.OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT_CODE);
         OfferDTO offer ;
+
         try {
             offer = getOfferById(offerID);
         } catch (RuntimeException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Offer not found with id: " + offerID, e);
         }
+        System.out.println("Interviews: " + offer.interviews());
+
         String offerDescription = offer.description();
         String formattedDescription = mockFlag ? OfferFormattedDescriptionPromptConstants.JSON_MOCK
                 : getOfferFormattedDescriptionFromAIByPrompt(prompt,offerDescription);
-        OfferDTO offerWithFormattedDescription = new OfferDTO(offerID,offer.title(),offerDescription,formattedDescription,offer.interviews());
-        OfferDTO savedOffer = updateOffer(offerID,offerWithFormattedDescription);
-        return offerMapper.mapJsonToDTO(savedOffer.formattedDescription());
+        setFormattedDescription(offerID,formattedDescription);
+        return offerMapper.mapJsonToDTO(formattedDescription);
     }
 
     @Override
@@ -126,5 +130,17 @@ public class OfferServImpl implements OfferServ {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Offer not found with id: " + offerId, e);
         }
         return offerMapper.mapJsonToDTO(offer.formattedDescription());
+    }
+
+    @Override
+    public int setFormattedDescription(UUID offerID, String formattedDescription){
+        int updatedRows = offerRepository.updateFormattedDescriptionById(offerID,formattedDescription);
+        if (updatedRows == 0) {
+            throw new ResponseStatusException(
+                    HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Failed to update formatted description for offer with id: " + offerID
+            );
+        }
+        return updatedRows;
     }
 }

--- a/src/main/java/ma/nttdata/externals/module/offer/service/impl/OfferServImpl.java
+++ b/src/main/java/ma/nttdata/externals/module/offer/service/impl/OfferServImpl.java
@@ -96,7 +96,7 @@ public class OfferServImpl implements OfferServ {
                 .replace(OfferFormattedDescriptionPromptConstants.OFFER_DESCRIPTION_PLACEHOLDER,offerDescription);
 
         return aiRestClient.post()
-                .uri("/extractFormattedDescription")
+                .uri("/extractOfferFormattedDescription")
                 .body(promptDesc)
                 .retrieve()
                 .body(String.class);
@@ -112,7 +112,6 @@ public class OfferServImpl implements OfferServ {
         } catch (RuntimeException e) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Offer not found with id: " + offerID, e);
         }
-        System.out.println("Interviews: " + offer.interviews());
 
         String offerDescription = offer.description();
         String formattedDescription = mockFlag ? OfferFormattedDescriptionPromptConstants.JSON_MOCK

--- a/src/main/java/ma/nttdata/externals/module/offer/service/impl/OfferServImpl.java
+++ b/src/main/java/ma/nttdata/externals/module/offer/service/impl/OfferServImpl.java
@@ -1,12 +1,20 @@
 package ma.nttdata.externals.module.offer.service.impl;
 import jakarta.transaction.Transactional;
+import ma.nttdata.externals.commons.constants.OfferFormattedDescriptionPromptConstants;
+import ma.nttdata.externals.commons.exception.ResourceNotFoundException;
 import ma.nttdata.externals.module.offer.dto.OfferDTO;
+import ma.nttdata.externals.module.offer.dto.OfferFormattedDescriptionDTO;
 import ma.nttdata.externals.module.offer.entity.Offer;
 import ma.nttdata.externals.module.offer.mapper.OfferMapper;
 import ma.nttdata.externals.module.offer.repository.OfferRepository;
 import ma.nttdata.externals.module.offer.service.OfferServ;
+import ma.nttdata.externals.module.prompt.dto.PromptDTO;
+import ma.nttdata.externals.module.prompt.service.PromptService;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
@@ -18,10 +26,18 @@ public class OfferServImpl implements OfferServ {
 
     private final OfferRepository offerRepository;
     private final OfferMapper offerMapper;
+    private final boolean mockFlag;
+    private final RestClient aiRestClient;
+    private final PromptService promptService;
 
-    public OfferServImpl(OfferRepository offerRepository, OfferMapper offerMapper) {
+    public OfferServImpl(OfferRepository offerRepository, OfferMapper offerMapper,
+                         @Value("${app.mock.flag}")boolean mockFlag,
+                         @Qualifier("aiServiceClient") RestClient aiRestClient, PromptService promptService) {
         this.offerRepository = offerRepository;
         this.offerMapper = offerMapper;
+        this.mockFlag = mockFlag;
+        this.aiRestClient = aiRestClient;
+        this.promptService = promptService;
     }
 
     // create srv
@@ -68,5 +84,47 @@ public class OfferServImpl implements OfferServ {
         return offerRepository.findDistinctTitles();
     }
 
+    @Override
+    public String getOfferFormattedDescriptionFromAIByPrompt(PromptDTO prompt,String offerDescription){
 
+        String promptDesc = prompt.promptDesc();
+
+        promptDesc = promptDesc.replace(OfferFormattedDescriptionPromptConstants.JSON_MOCK_PLACEHOLDER,OfferFormattedDescriptionPromptConstants.JSON_MOCK)
+                .replace(OfferFormattedDescriptionPromptConstants.JSON_SCHEMA_PLACEHOLDER,OfferFormattedDescriptionPromptConstants.JSON_SCHEMA)
+                .replace(OfferFormattedDescriptionPromptConstants.OFFER_DESCRIPTION_PLACEHOLDER,offerDescription);
+
+        return aiRestClient.post()
+                .uri("/extractFormattedDescription")
+                .body(promptDesc)
+                .retrieve()
+                .body(String.class);
+    }
+
+    @Override
+    public OfferFormattedDescriptionDTO prepareFormattedDescriptionByPrompt(UUID offerID){
+        PromptDTO prompt = promptService.findByPromptCode(OfferFormattedDescriptionPromptConstants.OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT_CODE);
+        OfferDTO offer ;
+        try {
+            offer = getOfferById(offerID);
+        } catch (RuntimeException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Offer not found with id: " + offerID, e);
+        }
+        String offerDescription = offer.description();
+        String formattedDescription = mockFlag ? OfferFormattedDescriptionPromptConstants.JSON_MOCK
+                : getOfferFormattedDescriptionFromAIByPrompt(prompt,offerDescription);
+        OfferDTO offerWithFormattedDescription = new OfferDTO(offerID,offer.title(),offerDescription,formattedDescription,offer.interviews());
+        OfferDTO savedOffer = updateOffer(offerID,offerWithFormattedDescription);
+        return offerMapper.mapJsonToDTO(savedOffer.formattedDescription());
+    }
+
+    @Override
+    public OfferFormattedDescriptionDTO getFormattedDescription(UUID offerId){
+        OfferDTO offer;
+        try {
+            offer = getOfferById(offerId);
+        } catch (RuntimeException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Offer not found with id: " + offerId, e);
+        }
+        return offerMapper.mapJsonToDTO(offer.formattedDescription());
+    }
 }

--- a/src/main/resources/db/insertion/Data.sql
+++ b/src/main/resources/db/insertion/Data.sql
@@ -228,7 +228,7 @@ JOIN language_data ld ON ld.row_number = cl.lang_index;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- OFFERS
-INSERT INTO offers (id, title, description)
+INSERT INTO offers (id, title, description,formatted_description)
 SELECT
     uuid_generate_v4(),
     (ARRAY[
@@ -250,7 +250,15 @@ SELECT
         'Create cross-platform mobile applications.',
         'Design and implement scalable cloud infrastructure.',
         'Build robust backend services and APIs.'
-    ])[FLOOR(RANDOM() * 8) + 1]
+    ])[FLOOR(RANDOM() * 8) + 1],
+    CAST(
+        json_build_object(
+            'skills',       (ARRAY['Java','React','Kubernetes','SQL'])[FLOOR(RANDOM()*4)+1],
+            'education',    (ARRAY['Bachelor','Master','PhD'])[FLOOR(RANDOM()*3)+1],
+            'yearsOfExperience', FLOOR(RANDOM() * 10) + 1,
+            'languages',    (ARRAY['English','French','Spanish','German'])[FLOOR(RANDOM()*4)+1]
+        ) AS text
+    )
 FROM generate_series(1, 10);
 
 -- INTERVIEWS

--- a/src/main/resources/db/insertion/Data.sql
+++ b/src/main/resources/db/insertion/Data.sql
@@ -252,13 +252,25 @@ SELECT
         'Build robust backend services and APIs.'
     ])[FLOOR(RANDOM() * 8) + 1],
     CAST(
-        json_build_object(
-            'skills',       (ARRAY['Java','React','Kubernetes','SQL'])[FLOOR(RANDOM()*4)+1],
-            'education',    (ARRAY['Bachelor','Master','PhD'])[FLOOR(RANDOM()*3)+1],
-            'yearsOfExperience', FLOOR(RANDOM() * 10) + 1,
-            'languages',    (ARRAY['English','French','Spanish','German'])[FLOOR(RANDOM()*4)+1]
-        ) AS text
-    )
+    json_build_object(
+        'description', 'We are seeking a highly skilled Senior Java Developer...',
+        'mainTech', 'Full Stack Javascript',
+        'skills', (ARRAY[
+            'Java - Spring Boot - Docker - Kubernetes - AWS',
+            'React - Node.js - MongoDB - Docker - Git',
+            'Python - Django - PostgresSQL - Kubernetes - AWS',
+            'C# - .NET - SQL Server - Azure - Agile'
+        ])[FLOOR(RANDOM() * 4) + 1],
+        'languages', json_build_array(
+            json_build_object('languageName', (ARRAY['English','French','Spanish','German'])[FLOOR(RANDOM()*4)+1], 'level', 'ADVANCED'),
+            json_build_object('languageName', (ARRAY['English','French','Spanish','German'])[FLOOR(RANDOM()*4)+1], 'level', 'INTERMEDIATE')
+        ),
+        'yearsOfExperience', FLOOR(RANDOM() * 10) + 1,
+        'mainResponsibilities', 'Design and implement microservices architecture...',
+        'education', 'Bachelor in Computer Science - Master in Software Engineering',
+        'keywords', 'Java - Spring Boot - Microservices - Docker - Kubernetes - Fintech - Agile - DevOps - AWS - Backend Development'
+    ) AS text
+  )
 FROM generate_series(1, 10);
 
 -- INTERVIEWS

--- a/src/main/resources/db/migration/V1__Create_user_and_candidate_tables.sql
+++ b/src/main/resources/db/migration/V1__Create_user_and_candidate_tables.sql
@@ -195,31 +195,28 @@ INSERT INTO prompts (prompt_code, prompt_desc, schema) VALUES (
 ),
 (
 'OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT',
- 'You are an expert HR data extraction specialist. Your task is to extract key information from job offer descriptions to create structured, formatted data for frontend display in our interview system.
-        I will give you the the information for the #offerDescription, #JSON_MOCK an example of the data we want and #JSON_SCHEMA you should respect when extracting information.
-        Take these instructions into consideration:
-        - description: The main job description and company information (keep the original descriptive content for display)
-        - mainTech: The primary technology stack or focus of the job, formatted like skills (format: "Tech,Level"), e.g., "Java,ADVANCED"
-        - skills: Technical and professional skills required with proficiency levels (format: "Skill,Level - Skill,Level"), e.g., "Java,ADVANCED - Spring Boot,INTERMEDIATE - Docker,BEGINNER"
-        - languages: Required languages with proficiency levels converted to enum values using mapping: A1, A2, Basic, Elementary → BEGINNER; B1, Lower Intermediate → LOWER_INTERMEDIATE; B2, Intermediate → INTERMEDIATE; C1, Upper Intermediate → UPPER_INTERMEDIATE; C2, Advanced, Fluent, Native → ADVANCED, and for the names of languages they should be in english.
-        - yearsOfExperience: Minimum years of experience (from "3-5 years" extract 3, from "5+ years" extract 5)
-        - mainResponsibilities: Core day-to-day tasks and duties the candidate will perform, separated by " - "
-        - education: Required degree level and field of study, separated by " - "
-        - keywords: Key terms from job title, critical skills, and industry-specific terminology that don''t fit in other categories
-
-        Return ONLY a valid JSON object with exactly this structure, no additional text or formatting: "{JSON_SCHEMA}"
-
-        Here is an example of the expected output: "{JSON_MOCK}"
-
-        Job Offer Description to extract from: "{OFFER_DESCRIPTION}". ',
+ 'You are an expert HR data extraction specialist.
+ I will give you an #Offer_Description, Extract the key information from it, and return a structured, formatted Json like provided in #JSON_SCHEMA, when extracting information, respect the schema we want an exact match, we''ll provide also a and #JSON_MOCK to help with that.
+Take these instructions into consideration:
+-For all the fields, keep the original text from the provided description just extract from it what matches the criteria.
+-description: The main offer description and company information (keep the original text from the provided description just extract from it).
+- skills: The required technical and professional skills.
+ - languages: The required language names and the proficiency levels. the names should be in English, the proficiency level should be one of these words: [BEGINNER, LOWER_INTERMEDIATE ,INTERMEDIATE, UPPER_INTERMEDIATE, ADVANCED], it might not be present in the description with the exact name, detect the required language level, and convert it accordignly to one of these values.
+ - yearsOfExperience: The required years of experience in the offer description (from "3-5 years" extract 3, from "5+ years" extract 5).
+ - mainResponsibilities: The tasks and duties mentioned in the offer description, that the candidate will perform if he got accepted in the offer.
+ - education: The required education from the offer description.
+ - keywords: The keywords of the offer description.
+ Return only a valid JSON object with exactly this structure, no additional text or formatting,  #JSON_SCHEMA structure: "{JSON_SCHEMA}"
+ Here is an example of the expected output, #JSON_MOCK structure: "{JSON_MOCK}"
+ #Offer_Description: "{OFFER_DESCRIPTION}"',
  '{
-    "description": "string - The job description text",
-    "mainTech": "string - Primary technology stack or focus, e.g., ''Java,ADVANCED''",
-    "skills": "string - Comma-separated skills with levels, e.g., ''Java,ADVANCED - Spring Boot,INTERMEDIATE''",
+    "description": "string ",
+    "mainTech": "string - Primary technology stack or focus, e.g., ''Full stack Java SpringBoot''",
+    "skills": "string - Offer required skills separated by '' - '' e.g., ''Java - Spring Boot - Docker''",
     "languages": "array of objects - [{''languageName'': ''English'', ''level'': ''ADVANCED''}]",
-    "yearsOfExperience": "integer - Minimum years of experience",
-    "mainResponsibilities": "string - Core tasks separated by '' - ''",
+    "yearsOfExperience": "integer - Minimum required years of experience",
+    "mainResponsibilities": "string - offer tasks separated by '' - ''",
     "education": "string - Education requirements separated by '' - ''",
-    "keywords": "string - Key terms separated by '' - ''"
- }'
+    "keywords": "string - Offer Keywords separated by '' - ''"
+}'
 );

--- a/src/main/resources/db/migration/V1__Create_user_and_candidate_tables.sql
+++ b/src/main/resources/db/migration/V1__Create_user_and_candidate_tables.sql
@@ -192,4 +192,34 @@ INSERT INTO prompts (prompt_code, prompt_desc, schema) VALUES (
                 "durationInMinutes": "integer - Duration in minutes (2-5)"
               }
             ]'
+),
+(
+'OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT',
+ 'You are an expert HR data extraction specialist. Your task is to extract key information from job offer descriptions to create structured, formatted data for frontend display in our interview system.
+        I will give you the the information for the #offerDescription, #JSON_MOCK an example of the data we want and #JSON_SCHEMA you should respect when extracting information.
+        Take these instructions into consideration:
+        - description: The main job description and company information (keep the original descriptive content for display)
+        - mainTech: The primary technology stack or focus of the job, formatted like skills (format: "Tech,Level"), e.g., "Java,ADVANCED"
+        - skills: Technical and professional skills required with proficiency levels (format: "Skill,Level - Skill,Level"), e.g., "Java,ADVANCED - Spring Boot,INTERMEDIATE - Docker,BEGINNER"
+        - languages: Required languages with proficiency levels converted to enum values using mapping: A1, A2, Basic, Elementary → BEGINNER; B1, Lower Intermediate → LOWER_INTERMEDIATE; B2, Intermediate → INTERMEDIATE; C1, Upper Intermediate → UPPER_INTERMEDIATE; C2, Advanced, Fluent, Native → ADVANCED, and for the names of languages they should be in english.
+        - yearsOfExperience: Minimum years of experience (from "3-5 years" extract 3, from "5+ years" extract 5)
+        - mainResponsibilities: Core day-to-day tasks and duties the candidate will perform, separated by " - "
+        - education: Required degree level and field of study, separated by " - "
+        - keywords: Key terms from job title, critical skills, and industry-specific terminology that don''t fit in other categories
+
+        Return ONLY a valid JSON object with exactly this structure, no additional text or formatting: "{JSON_SCHEMA}"
+
+        Here is an example of the expected output: "{JSON_MOCK}"
+
+        Job Offer Description to extract from: "{OFFER_DESCRIPTION}". ',
+ '{
+    "description": "string - The job description text",
+    "mainTech": "string - Primary technology stack or focus, e.g., ''Java,ADVANCED''",
+    "skills": "string - Comma-separated skills with levels, e.g., ''Java,ADVANCED - Spring Boot,INTERMEDIATE''",
+    "languages": "array of objects - [{''languageName'': ''English'', ''level'': ''ADVANCED''}]",
+    "yearsOfExperience": "integer - Minimum years of experience",
+    "mainResponsibilities": "string - Core tasks separated by '' - ''",
+    "education": "string - Education requirements separated by '' - ''",
+    "keywords": "string - Key terms separated by '' - ''"
+ }'
 );

--- a/src/main/resources/db/migration/V2__Offers__and__interviews__tables.sql
+++ b/src/main/resources/db/migration/V2__Offers__and__interviews__tables.sql
@@ -10,7 +10,8 @@ DROP TABLE IF EXISTS offers CASCADE;
 CREATE TABLE IF NOT EXISTS offers (
     id UUID PRIMARY KEY,
     title VARCHAR(255) NOT NULL,
-    description TEXT
+    description TEXT,
+    formatted_description TEXT
 );
 
 -- Interviews table

--- a/src/test/java/ma/nttdata/externals/module/interview/controller/InterviewControllerTest.java
+++ b/src/test/java/ma/nttdata/externals/module/interview/controller/InterviewControllerTest.java
@@ -148,6 +148,7 @@ class InterviewControllerTest {
                 offerId,
                 "Backend Engineer",
                 "We need a backend engineer with solid experience in Node js and spring boot",
+                null,
                 List.of(interviewDTO)
         );
     }

--- a/src/test/java/ma/nttdata/externals/module/interview/service/impl/EvaluationServImplTest.java
+++ b/src/test/java/ma/nttdata/externals/module/interview/service/impl/EvaluationServImplTest.java
@@ -273,7 +273,7 @@ public class EvaluationServImplTest {
         );
 
         CandidateDTO candidateDTO = new CandidateDTO(UUID.randomUUID(), "John Doe", null, 0, null, null, null, null, null, null, null, null, null, null, null);
-        OfferDTO offerDTO = new OfferDTO(UUID.randomUUID(), "Java Developer", null, null);
+        OfferDTO offerDTO = new OfferDTO(UUID.randomUUID(), "Java Developer", null, null, null);
         EvaluationType tech = new EvaluationType();
         tech.setId(UUID.randomUUID());
         tech.setDescription("Technical");

--- a/src/test/java/ma/nttdata/externals/module/interview/service/impl/InterviewSrvImplTest.java
+++ b/src/test/java/ma/nttdata/externals/module/interview/service/impl/InterviewSrvImplTest.java
@@ -306,7 +306,7 @@ class InterviewSrvImplTest {
         interview.setEvaluations(evaluations);
 
         CandidateDTO candidateDTO = new CandidateDTO(candidate.getId(), null, null, 0, null, null, null, null, null, null, null, null, null, null, null);
-        OfferDTO offerDTO = new OfferDTO(offer.getId(), null, null, null);
+        OfferDTO offerDTO = new OfferDTO(offer.getId(), null, null, null, null);
 
         when(interviewRepository.findWithCandidateWithoutContactsAndOfferById(interviewId)).thenReturn(Optional.of(interview));
         when(candidateMapper.candidateToCandidateDTO(candidate)).thenReturn(candidateDTO);
@@ -355,7 +355,7 @@ class InterviewSrvImplTest {
         interview.setEstimatedDuration(30);
         interview.setNumberOfQuestions(15);
         CandidateDTO candidateDTO = new CandidateDTO(candidate.getId(), "habib", null, 0, null, null, null, null, null, null, null, null, null, null, null);
-        OfferDTO offerDTO = new OfferDTO(offer.getId(), "Backend Engineer", null, null);
+        OfferDTO offerDTO = new OfferDTO(offer.getId(), "Backend Engineer", null, null,null);
 
         when(interviewRepository.findById(interviewId)).thenReturn(Optional.of(interview));
         when(candidateMapper.candidateToCandidateDTO(candidate)).thenReturn(candidateDTO);
@@ -483,6 +483,7 @@ class InterviewSrvImplTest {
                 UUID.randomUUID(),
                 "Backend Developer",
                 "just testing",
+                null,
                 null
         );
 

--- a/src/test/java/ma/nttdata/externals/module/interview/service/impl/QuestionServiceImplTest.java
+++ b/src/test/java/ma/nttdata/externals/module/interview/service/impl/QuestionServiceImplTest.java
@@ -85,7 +85,7 @@ public class QuestionServiceImplTest {
                 true,
                 aiRestClient);
         CandidateDTO candidateDTO = new CandidateDTO(UUID.randomUUID(), null, null, 0, null, null, null, null, null, null, null, null, null, null, null);
-        OfferDTO offerDTO = new OfferDTO(UUID.randomUUID(), null, null, null);
+        OfferDTO offerDTO = new OfferDTO(UUID.randomUUID(), null, null, null,null);
 
         placeholdersForInterviewQuestionsPromptDTO generateQuestionsInfo = new placeholdersForInterviewQuestionsPromptDTO(
                 candidateDTO,

--- a/src/test/java/ma/nttdata/externals/module/offer/controller/OfferControllerTest.java
+++ b/src/test/java/ma/nttdata/externals/module/offer/controller/OfferControllerTest.java
@@ -7,10 +7,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Arrays;
@@ -35,7 +35,7 @@ class OfferControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private OfferServ offerService;
 
     private OfferDTO offerDTO;
@@ -48,6 +48,7 @@ class OfferControllerTest {
                 offerId,
                 "Java Developer",
                 "Looking for a senior Java developer.",
+                "null",
                 Collections.emptyList()
         );
     }
@@ -62,6 +63,7 @@ class OfferControllerTest {
                 null,
                 "Java Developer",
                 "Looking for a senior Java developer.",
+                "null",
                 Collections.emptyList()
         );
 
@@ -70,6 +72,7 @@ class OfferControllerTest {
                 fixedOfferId,
                 "Java Developer",
                 "Looking for a senior Java developer.",
+                "null",
                 Collections.emptyList()
         );
 
@@ -113,6 +116,7 @@ class OfferControllerTest {
                 offerId,
                 "Senior Java Developer",
                 "Looking for a senior Java developer with 5+ years experience.",
+                "null",
                 Collections.emptyList()
         );
 
@@ -155,7 +159,7 @@ class OfferControllerTest {
         //w
         List<OfferDTO> offers = Arrays.asList(
                 offerDTO,
-                new OfferDTO(UUID.randomUUID(), "Python Developer", "Need a Python expert." ,     Collections.emptyList())
+                new OfferDTO(UUID.randomUUID(), "Python Developer", "Need a Python expert." , null,    Collections.emptyList())
 
         );
 

--- a/src/test/java/ma/nttdata/externals/module/offer/mapper/OfferMapperTest.java
+++ b/src/test/java/ma/nttdata/externals/module/offer/mapper/OfferMapperTest.java
@@ -1,43 +1,62 @@
 package ma.nttdata.externals.module.offer.mapper;
 
-import ma.nttdata.externals.module.interview.dto.InterviewDTO;
-import ma.nttdata.externals.module.interview.mapper.InterviewMapper;
+import ma.nttdata.externals.commons.constants.OfferFormattedDescriptionPromptConstants;
 import ma.nttdata.externals.module.offer.dto.OfferDTO;
+import ma.nttdata.externals.module.offer.dto.OfferFormattedDescriptionDTO;
 import ma.nttdata.externals.module.offer.entity.Offer;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
 
 import java.util.Collections;
-import java.util.List;
 
-@Component
-public class OfferMapperTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
-    @Autowired
-    private InterviewMapper interviewMapper;
+class OfferMapperTest {
 
-    public OfferDTO offerToOfferDTO(Offer offer) {
-        if (offer == null) return null;
-        List<InterviewDTO> interviewDTOs = offer.getInterviews() != null
-                ? interviewMapper.toDtoList(offer.getInterviews())
-                : Collections.emptyList();
-        return new OfferDTO(
-                offer.getId(),
-                offer.getTitle(),
-                offer.getDescription(),
-                interviewDTOs
-        );
+    private final OfferMapper offerMapper = Mappers.getMapper(OfferMapper.class);
+
+    @Test
+    void testOfferToOfferDTO() {
+        Offer offer = new Offer();
+        offer.setId(java.util.UUID.randomUUID());
+        offer.setTitle("Java Developer");
+        offer.setDescription("Job description");
+        offer.setInterviews(Collections.emptyList());
+
+        OfferDTO dto = offerMapper.toDto(offer);
+
+        assertNotNull(dto);
+        assertEquals(offer.getId(), dto.id());
+        assertEquals(offer.getTitle(), dto.title());
+        assertEquals(offer.getDescription(), dto.description());
     }
 
-    public Offer offerDTOToOffer(OfferDTO dto) {
-        if (dto == null) return null;
-        Offer offer = new Offer();
-        offer.setId(dto.id());
-        offer.setTitle(dto.title());
-        offer.setDescription(dto.description());
-        offer.setInterviews(dto.interviews() != null
-                ? interviewMapper.toEntityList(dto.interviews())
-                : Collections.emptyList());
-        return offer;
+    @Test
+    void testOfferDTOToOffer() {
+        OfferDTO dto = new OfferDTO(
+                java.util.UUID.randomUUID(),
+                "Java Developer",
+                "Job description",
+                "",
+                Collections.emptyList()
+        );
+
+        Offer offer = offerMapper.toEntity(dto);
+
+        assertNotNull(offer);
+        assertEquals(dto.id(), offer.getId());
+        assertEquals(dto.title(), offer.getTitle());
+        assertEquals(dto.description(), offer.getDescription());
+    }
+
+    @Test
+    void mapTOJson_should_return_valid_OfferFormattedDescriptionDTO(){
+
+        OfferFormattedDescriptionDTO result = offerMapper.mapJsonToDTO(
+                OfferFormattedDescriptionPromptConstants.JSON_MOCK);
+
+        assertNotNull(result);
+        assertThat(result.description()).isEqualTo("We are seeking a highly skilled Senior Java Developer to join our dynamic fintech team. The role involves designing and implementing scalable microservices, collaborating with cross-functional teams, and ensuring high-quality code standards. The candidate will contribute to architecture decisions, mentor junior developers, and help drive the adoption of best practices.");
     }
 }

--- a/src/test/java/ma/nttdata/externals/module/offer/service/impl/OfferSrvImplTest.java
+++ b/src/test/java/ma/nttdata/externals/module/offer/service/impl/OfferSrvImplTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.web.client.RestClient;
 
 import java.util.*;
 
@@ -22,6 +23,11 @@ class OfferSrvImplTest {
 
     @Mock
     private OfferMapper offerMapper;
+
+     private boolean mockFlag ;
+
+    @Mock
+    private RestClient aiRestClient;
 
     @InjectMocks
     private OfferServImpl offerServImpl;

--- a/src/test/java/ma/nttdata/externals/module/offer/service/impl/OfferSrvImplTest.java
+++ b/src/test/java/ma/nttdata/externals/module/offer/service/impl/OfferSrvImplTest.java
@@ -4,6 +4,7 @@ import ma.nttdata.externals.module.offer.dto.OfferDTO;
 import ma.nttdata.externals.module.offer.entity.Offer;
 import ma.nttdata.externals.module.offer.mapper.OfferMapper;
 import ma.nttdata.externals.module.offer.repository.OfferRepository;
+import ma.nttdata.externals.module.prompt.service.PromptService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -23,13 +24,12 @@ class OfferSrvImplTest {
 
     @Mock
     private OfferMapper offerMapper;
-
-     private boolean mockFlag ;
-
     @Mock
     private RestClient aiRestClient;
+    @Mock
+    private PromptService promptService;
 
-    @InjectMocks
+
     private OfferServImpl offerServImpl;
 
     private Offer offer;
@@ -50,12 +50,20 @@ class OfferSrvImplTest {
                 offerId,
                 "Frontend Developer",
                 "Looking for a React expert" ,
+                null,
                 Collections.emptyList()
         );
     }
 
     @Test
     void testCreateOffer() {
+        offerServImpl = new OfferServImpl(
+                offerRepository,
+                offerMapper,
+                true,
+                aiRestClient,
+                promptService
+        );
         when(offerMapper.toEntity(offerDTO)).thenReturn(offer);
         when(offerRepository.save(offer)).thenReturn(offer);
         when(offerMapper.toDto(offer)).thenReturn(offerDTO);
@@ -69,6 +77,14 @@ class OfferSrvImplTest {
 
     @Test
     void testGetOfferById() {
+        offerServImpl = new OfferServImpl(
+                offerRepository,
+                offerMapper,
+                true,
+                aiRestClient,
+                promptService
+        );
+
         when(offerRepository.findById(offerId)).thenReturn(Optional.of(offer));
         when(offerMapper.toDto(offer)).thenReturn(offerDTO);
 
@@ -81,6 +97,14 @@ class OfferSrvImplTest {
 
     @Test
     void testGetAllOffers() {
+        offerServImpl = new OfferServImpl(
+                offerRepository,
+                offerMapper,
+                true,
+                aiRestClient,
+                promptService
+        );
+
         List<Offer> offers = Arrays.asList(offer);
         List<OfferDTO> offerDTOs = Arrays.asList(offerDTO);
 
@@ -96,6 +120,14 @@ class OfferSrvImplTest {
 
     @Test
     void testUpdateOffer() {
+        offerServImpl = new OfferServImpl(
+                offerRepository,
+                offerMapper,
+                true,
+                aiRestClient,
+                promptService
+        );
+
         when(offerRepository.findById(offerId)).thenReturn(Optional.of(offer));
         when(offerMapper.toEntity(offerDTO)).thenReturn(offer);
         when(offerRepository.save(offer)).thenReturn(offer);
@@ -110,6 +142,14 @@ class OfferSrvImplTest {
 
     @Test
     void testDeleteOffer() {
+        offerServImpl = new OfferServImpl(
+                offerRepository,
+                offerMapper,
+                true,
+                aiRestClient,
+                promptService
+        );
+
         when(offerRepository.findById(offerId)).thenReturn(Optional.of(offer));
 
         offerServImpl.deleteOffer(offerId);


### PR DESCRIPTION
Added OfferFormattedDescriptionPromptConstants for AI prompt, JSON schema, and mock data.

Implemented prepareFormattedDescriptionByPrompt in OfferServImpl to generate structured offer descriptions from free-text using AI or mock data.

Created OfferFormattedDescriptionDTO and OfferFormattedDescriptionLanguageDTO to store formatted offer details including skills, tech, languages, experience, responsibilities, education, and keywords.

Updated repository with updateFormattedDescriptionById to persist formatted JSON.

Added error handling for missing offers or failed updates.