### PR TITLE
Adding missing tests

### DIFF
--- a/src/main/java/ma/nttdata/externals/module/interview/controller/InterviewController.java
+++ b/src/main/java/ma/nttdata/externals/module/interview/controller/InterviewController.java
@@ -259,6 +259,10 @@ public class InterviewController  {
         return ResponseEntity.ok(interviewServ.getInterviewEvaluations(interviewId));
     }
 
+    @Operation(
+            summary = "Get all the audios of the questions of an interview",
+            description = "Returns the zip of the list of the audios"
+    )
     @GetMapping("/{interviewId}/generateQuestionsAudios")
     public ResponseEntity<byte[]> getInterviewQuestionsAudios(@PathVariable UUID interviewId) throws IOException {
         return interviewServ.generateInterviewQuestionsAudios(interviewId);

--- a/src/main/java/ma/nttdata/externals/module/interview/controller/QuestionController.java
+++ b/src/main/java/ma/nttdata/externals/module/interview/controller/QuestionController.java
@@ -77,6 +77,11 @@ public class QuestionController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "Generate audio of a question")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Audio generated successfully"),
+            @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
     @PostMapping("/generateAudio")
     public ResponseEntity<byte[]> generateQuestionAudio(@RequestBody TtsRequestDTO ttsRequestDTO){
         return questionServ.generateInterviewQuestionAudio(ttsRequestDTO.text());

--- a/src/main/java/ma/nttdata/externals/module/interview/service/impl/InterviewServImpl.java
+++ b/src/main/java/ma/nttdata/externals/module/interview/service/impl/InterviewServImpl.java
@@ -228,7 +228,7 @@ public class InterviewServImpl implements InterviewServ {
     @Override
     public String saveInterviewLink(String token, UUID interviewId) {
         Interview interview = interviewRepository.findById(interviewId)
-                .orElseThrow(() -> new ResourceNotFoundException("Interview not found",interviewId));
+                .orElseThrow(() -> new ResourceNotFoundException("Interview",interviewId));
 
 
         String interviewLink = interviewBaseLink+token;
@@ -239,7 +239,7 @@ public class InterviewServImpl implements InterviewServ {
     @Override
     public placeholdersForInterviewQuestionsPromptDTO getPlaceholdersForInterviewQuestionsPrompt(UUID interviewId){
         Interview interview = interviewRepository.findWithCandidateWithoutContactsAndOfferById(interviewId)
-                .orElseThrow(() -> new ResourceNotFoundException("Interview not found with ID: " + interviewId));
+                .orElseThrow(() -> new ResourceNotFoundException("Interview" + interviewId));
 
         CandidateDTO candidate = candidateMapper.candidateToCandidateDTO(interview.getCandidate());
 
@@ -258,7 +258,7 @@ public class InterviewServImpl implements InterviewServ {
     @Override
     public SendEmailDTO getEmailInfo(UUID interviewId){
         Interview interview = interviewRepository.findWithCandidateAndOfferById(interviewId)
-                .orElseThrow(() -> new ResourceNotFoundException("Interview not found",interviewId));;
+                .orElseThrow(() -> new ResourceNotFoundException("Interview",interviewId));;
 
         Candidate candidate = interview.getCandidate();
         Offer offer = interview.getOffer();

--- a/src/main/resources/db/migration/V2__Offers__and__interviews__tables.sql
+++ b/src/main/resources/db/migration/V2__Offers__and__interviews__tables.sql
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS interviews (
         REFERENCES offers(id)
         ON DELETE CASCADE
 );
+ALTER TABLE interviews ALTER COLUMN link TYPE VARCHAR(500);
 
 -- Evaluation types
 CREATE TABLE IF NOT EXISTS evaluation_types (

--- a/src/main/resources/db/migration/V2__Offers__and__interviews__tables.sql
+++ b/src/main/resources/db/migration/V2__Offers__and__interviews__tables.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS interviews (
     startTime TIMESTAMP,
     endTime TIMESTAMP,
     description TEXT,
-    link VARCHAR(255),
+    link VARCHAR(500),
     feedback_general VARCHAR(255),
     scheduled_at TIMESTAMP,
     comment VARCHAR(255),
@@ -40,7 +40,6 @@ CREATE TABLE IF NOT EXISTS interviews (
         REFERENCES offers(id)
         ON DELETE CASCADE
 );
-ALTER TABLE interviews ALTER COLUMN link TYPE VARCHAR(500);
 
 -- Evaluation types
 CREATE TABLE IF NOT EXISTS evaluation_types (

--- a/src/test/java/ma/nttdata/externals/module/interview/mapper/EvaluationMapperTest.java
+++ b/src/test/java/ma/nttdata/externals/module/interview/mapper/EvaluationMapperTest.java
@@ -287,4 +287,44 @@ class EvaluationMapperTest {
         assertThat(evaluationTypeId2).isEqualTo( secondEval.evaluationType().id());
 
     }
+
+    @Test
+    void testToEntity_shouldSetInterviewAndEvaluationType() {
+        UUID interviewId = UUID.randomUUID();
+        UUID evaluationTypeId = UUID.randomUUID();
+
+        EvaluationDTO dto = new EvaluationDTO(
+                UUID.randomUUID(),
+                5.0,
+                "Strong skills",
+                interviewId,
+                evaluationTypeId
+        );
+
+        Evaluation entity = evaluationMapper.toEntity(dto);
+
+        assertNotNull(entity);
+        assertEquals(dto.id(), entity.getId());
+        assertEquals(dto.score(), entity.getScore());
+        assertEquals(dto.feedback(), entity.getFeedback());
+
+        assertNotNull(entity.getInterview());
+        assertEquals(interviewId, entity.getInterview().getId());
+
+        assertNotNull(entity.getEvaluationType());
+        assertEquals(evaluationTypeId, entity.getEvaluationType().getId());
+    }
+
+    @Test
+    void mapEvaluationToInterviewEvaluation_shouldReturnNull_whenListIsNull() {
+        InterviewEvaluationDTO dto = evaluationMapper.mapEvaluationToInterviewEvaluation(null);
+        assertNull(dto);
+    }
+
+    @Test
+    void mapEvaluationToInterviewEvaluation_shouldReturnNull_whenListIsEmpty() {
+        InterviewEvaluationDTO dto = evaluationMapper.mapEvaluationToInterviewEvaluation(List.of());
+        assertNull(dto);
+    }
+
 }

--- a/src/test/java/ma/nttdata/externals/module/interview/mapper/EvaluationTypeMapperTest.java
+++ b/src/test/java/ma/nttdata/externals/module/interview/mapper/EvaluationTypeMapperTest.java
@@ -1,0 +1,51 @@
+package ma.nttdata.externals.module.interview.mapper;
+
+import ma.nttdata.externals.module.interview.dto.EvaluationTypeDTO;
+import ma.nttdata.externals.module.interview.entity.EvaluationType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class EvaluationTypeMapperTest {
+
+    private final EvaluationTypeMapper mapper = Mappers.getMapper(EvaluationTypeMapper.class);
+
+    private EvaluationType evaluationType;
+    private EvaluationTypeDTO evaluationTypeDTO;
+
+    @BeforeEach
+    void setUp() {
+        evaluationType = new EvaluationType();
+        evaluationType.setId(UUID.randomUUID());
+        evaluationType.setDescription("this is an evaluation type for testing");
+        evaluationType.setCoefficient(3.0);
+
+        evaluationTypeDTO = new EvaluationTypeDTO(UUID.randomUUID(),"evaluation type DTO for test"
+        ,2.0);
+    }
+
+    @Test
+    void toDto_should_map_evaluationType_to_evaluationTypeDTO(){
+        EvaluationTypeDTO mapped = mapper.toDto(evaluationType);
+
+        assertThat(evaluationType.getId()).isEqualTo(mapped.id());
+        assertThat(evaluationType.getDescription()).isEqualTo(mapped.description());
+        assertThat(evaluationType.getCoefficient()).isEqualTo(mapped.coefficient());
+    }
+
+    @Test
+    void toEntity_should_map_correctly_evaluationTypeDto_to_entity(){
+        EvaluationType mappedEntity = mapper.toEntity(evaluationTypeDTO);
+
+        assertThat(mappedEntity.getId()).isEqualTo(evaluationTypeDTO.id());
+        assertThat(mappedEntity.getDescription()).isEqualTo(evaluationTypeDTO.description());
+        assertThat(mappedEntity.getCoefficient()).isEqualTo(evaluationTypeDTO.coefficient());
+    }
+}

--- a/src/test/java/ma/nttdata/externals/module/interview/service/impl/InterviewSrvImplTest.java
+++ b/src/test/java/ma/nttdata/externals/module/interview/service/impl/InterviewSrvImplTest.java
@@ -30,10 +30,15 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.crossstore.ChangeSetPersister;
+import org.springframework.http.ResponseEntity;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -812,5 +817,45 @@ class InterviewSrvImplTest {
         verify(promptServ).findByPromptCode(InterviewPromptConstants.INTERVIEW_GENERATE_QUESTIONS_PROMPT_CODE);
         verify(questionServ).prepareQuestionsFromAIResponse(placeholders, evaluationTypes, prompt);
         verify(questionServ).saveAllQuestions(anyList());
+    }
+
+    @Test
+    void testGenerateInterviewQuestionsAudios() throws IOException {
+        UUID interviewId = UUID.randomUUID();
+
+        List<QuestionDTO> questions = List.of(
+                new QuestionDTO(null, "Question 1", 10, interviewId, null),
+                new QuestionDTO(null, "Question 2", 15, interviewId, null)
+        );
+
+        when(questionServ.findAllQuestionsDTOSByInterviewId(interviewId)).thenReturn(questions);
+        when(textToSpeechServ.speak("Question 1")).thenReturn("audio1".getBytes());
+        when(textToSpeechServ.speak("Question 2")).thenReturn("audio2".getBytes());
+
+        ResponseEntity<byte[]> response = interviewServ.generateInterviewQuestionsAudios(interviewId);
+
+        assertNotNull(response);
+        assertEquals(200, response.getStatusCodeValue());
+        assertNotNull(response.getBody());
+        assertTrue(response.getBody().length > 0);
+
+        assertEquals(response.getBody().length, response.getHeaders().getContentLength());
+        assertEquals("application/octet-stream", response.getHeaders().getContentType().toString());
+
+        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(response.getBody()))) {
+            ZipEntry entry = zis.getNextEntry();
+            assertNotNull(entry);
+            assertEquals("question_1.mp3", entry.getName());
+
+            entry = zis.getNextEntry();
+            assertNotNull(entry);
+            assertEquals("question_2.mp3", entry.getName());
+
+            assertNull(zis.getNextEntry());
+        }
+
+        verify(questionServ, times(1)).findAllQuestionsDTOSByInterviewId(interviewId);
+        verify(textToSpeechServ, times(1)).speak("Question 1");
+        verify(textToSpeechServ, times(1)).speak("Question 2");
     }
 }

--- a/src/test/java/ma/nttdata/externals/module/interview/service/impl/InterviewSrvImplTest.java
+++ b/src/test/java/ma/nttdata/externals/module/interview/service/impl/InterviewSrvImplTest.java
@@ -1,9 +1,13 @@
 package ma.nttdata.externals.module.interview.service.impl;
 
 import ma.nttdata.externals.commons.constants.InterviewEvaluationPromptConstants;
+import ma.nttdata.externals.commons.constants.InterviewPromptConstants;
 import ma.nttdata.externals.commons.exception.ResourceNotFoundException;
+import ma.nttdata.externals.module.candidate.constants.GenderEnum;
 import ma.nttdata.externals.module.candidate.dto.CandidateDTO;
+import ma.nttdata.externals.module.candidate.dto.ContactDTO;
 import ma.nttdata.externals.module.candidate.entity.Candidate;
+import ma.nttdata.externals.module.candidate.entity.Contact;
 import ma.nttdata.externals.module.candidate.mapper.CandidateMapper;
 import ma.nttdata.externals.module.candidate.repository.CandidateRepository;
 import ma.nttdata.externals.module.interview.dto.*;
@@ -27,6 +31,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.crossstore.ChangeSetPersister;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -576,5 +581,236 @@ class InterviewSrvImplTest {
 
         verify(evaluationServ).getAllEvaluationsByInterviewID(interviewId);
         verify(evaluationMapper).mapEvaluationToInterviewEvaluation(List.of(evaluation));
+    }
+
+
+    @Test
+    void should_add_comment_to_interview(){
+        UUID interviewId = UUID.randomUUID();
+        String comment = "This is a new comment";
+
+        Interview interview = new Interview();
+        interview.setId(interviewId);
+        interview.setComment("Old comment");
+
+        Interview updatedInterview = new Interview();
+        updatedInterview.setId(interviewId);
+        updatedInterview.setComment(comment);
+
+        InterviewDTO interviewDTO = new InterviewDTO(
+                interviewId,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                comment,
+                0,
+                0,
+                null,
+                null,
+                null,
+                null
+        );
+
+        when(interviewRepository.findById(interviewId)).thenReturn(Optional.of(interview));
+        when(interviewRepository.save(any(Interview.class))).thenReturn(updatedInterview);
+        when(interviewMapper.toDto(updatedInterview)).thenReturn(interviewDTO);
+
+        InterviewDTO result = interviewServ.addCommentToInterview(interviewId, comment);
+
+        assertThat(result).isNotNull();
+        assertThat(result.comment()).isEqualTo(comment);
+
+        verify(interviewRepository).findById(interviewId);
+        verify(interviewRepository).save(interview);
+        verify(interviewMapper).toDto(updatedInterview);
+    }
+
+    @Test
+    void addCommentToInterview_shouldThrowException_whenInterviewNotFound() {
+        UUID interviewId = UUID.randomUUID();
+
+        when(interviewRepository.findById(interviewId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> interviewServ.addCommentToInterview(interviewId, "Any comment"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Interview not found with ID");
+
+        verify(interviewRepository).findById(interviewId);
+        verifyNoMoreInteractions(interviewRepository, interviewMapper);
+    }
+
+    @Test
+    void should_save_interview_link(){
+        Interview interview = new Interview();
+        interview.setId(UUID.randomUUID());
+        String token = "abc";
+        when(interviewRepository.findById(interview.getId())).thenReturn(Optional.of(interview));
+
+        when(interviewRepository.save(any(Interview.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        String result = interviewServ.saveInterviewLink(token, interview.getId());
+
+
+        assertEquals(TEST_BASE_LINK + token, result);
+        assertEquals(TEST_BASE_LINK + token, interview.getLink());
+        verify(interviewRepository).save(interview);
+    }
+
+    @Test
+    void save_interview_link_should_raise_an_error(){
+        UUID interviewId = UUID.randomUUID();
+
+        when(interviewRepository.findById(interviewId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> interviewServ.saveInterviewLink(TEST_BASE_LINK, interviewId))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Interview not found with id: "+interviewId);
+    }
+
+    @Test
+    void should_return_email_info_when_email_exists() {
+        UUID interviewId = UUID.randomUUID();
+        Candidate candidate = new Candidate();
+        candidate.setFullName("John Doe");
+        Contact emailContact = new Contact();
+        emailContact.setContactType("email");
+        emailContact.setContactValue("john@example.com");
+        candidate.setContacts(List.of(emailContact));
+
+        Offer offer = new Offer();
+        offer.setTitle("Software Engineer");
+
+        Interview interview = new Interview();
+        interview.setId(interviewId);
+        interview.setCandidate(candidate);
+        interview.setOffer(offer);
+        interview.setScheduledAt(LocalDateTime.of(2025, 8, 27, 10, 0));
+        interview.setLink(TEST_BASE_LINK+"abc");
+
+        when(interviewRepository.findWithCandidateAndOfferById(interviewId))
+                .thenReturn(Optional.of(interview));
+
+        SendEmailDTO dto = interviewServ.getEmailInfo(interviewId);
+
+        assertEquals("John Doe", dto.candidateFullName());
+        assertEquals("Software Engineer", dto.offerTitle());
+        assertEquals("john@example.com", dto.email());
+        assertEquals(interview.getScheduledAt(), dto.scheduledDate());
+        assertEquals(TEST_BASE_LINK+"abc", dto.link());
+    }
+
+    @Test
+    void should_throw_exception_when_interview_not_found() {
+        UUID interviewId = UUID.randomUUID();
+        when(interviewRepository.findWithCandidateAndOfferById(interviewId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> interviewServ.getEmailInfo(interviewId))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Interview not found with id: "+interviewId);
+    }
+
+    @Test
+    void should_throw_exception_when_candidate_email_not_found() {
+        UUID interviewId = UUID.randomUUID();
+        Candidate candidate = new Candidate();
+        candidate.setFullName("John Doe");
+        candidate.setContacts(Collections.emptyList());
+
+        Offer offer = new Offer();
+        offer.setTitle("Software Engineer");
+
+        Interview interview = new Interview();
+        interview.setId(interviewId);
+        interview.setCandidate(candidate);
+        interview.setOffer(offer);
+
+        when(interviewRepository.findWithCandidateAndOfferById(interviewId))
+                .thenReturn(Optional.of(interview));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> interviewServ.getEmailInfo(interviewId));
+        assertEquals("Candidate email not found", ex.getMessage());
+    }
+
+    @Test
+    void should_generate_and_save_questions() {
+        UUID interviewId = UUID.randomUUID();
+        List<UUID> evaluationTypeIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+        GenerateInterviewQuestionsRequest request = new GenerateInterviewQuestionsRequest(evaluationTypeIds);
+
+        ContactDTO contact = new ContactDTO(UUID.randomUUID(),"email", "john.doe@example.com");
+        List<ContactDTO> contacts = List.of(contact);
+        CandidateDTO candidate = new CandidateDTO(
+                UUID.randomUUID(),
+                "John Doe",
+                LocalDate.of(1990, 1, 1),
+                5,
+                GenderEnum.M,
+                "Java",
+                "Experienced Java developer",
+                contacts,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                null,
+                Collections.emptyList(),
+                Collections.emptyList()
+        );
+
+        OfferDTO offer = new OfferDTO(
+                UUID.randomUUID(),
+                "Java Developer",
+                "Backend Java developer position",
+                null,
+                Collections.emptyList()
+        );
+
+        placeholdersForInterviewQuestionsPromptDTO placeholders = new placeholdersForInterviewQuestionsPromptDTO(
+                candidate,
+                offer,
+                5,
+                60
+        );
+        List<EvaluationTypeDTO> evaluationTypes = List.of(
+                new EvaluationTypeDTO(UUID.randomUUID(), "Technical",2.0),
+                new EvaluationTypeDTO(UUID.randomUUID(), "Behavioral",3.0)
+        );
+        PromptDTO prompt = new PromptDTO(UUID.randomUUID(),InterviewPromptConstants.INTERVIEW_GENERATE_QUESTIONS_PROMPT_CODE,
+        InterviewPromptConstants.INTERVIEW_QUESTION_GENERATION_PROMPT,InterviewPromptConstants.JSON_SCHEMA);
+
+        List<QuestionDTO> aiGeneratedQuestions = List.of(
+                new QuestionDTO(null, "Question 1", 10, null, null),
+                new QuestionDTO(null, "Question 2", 15, null, null)
+        );
+
+        List<QuestionDTO> savedQuestions = List.of(
+                new QuestionDTO(UUID.randomUUID(), "Question 1", 10, interviewId, null),
+                new QuestionDTO(UUID.randomUUID(), "Question 2", 15, interviewId, null)
+        );
+
+        InterviewServImpl spyService = spy(interviewServ);
+        doReturn(placeholders).when(spyService).getPlaceholdersForInterviewQuestionsPrompt(interviewId);
+        when(evaluationTypeServ.findAllById(evaluationTypeIds)).thenReturn(evaluationTypes);
+        when(promptServ.findByPromptCode(InterviewPromptConstants.INTERVIEW_GENERATE_QUESTIONS_PROMPT_CODE)).thenReturn(prompt);
+        when(questionServ.prepareQuestionsFromAIResponse(placeholders, evaluationTypes, prompt)).thenReturn(aiGeneratedQuestions);
+        when(questionServ.saveAllQuestions(anyList())).thenReturn(savedQuestions);
+
+        List<QuestionDTO> result = spyService.generateInterviewQuestions(interviewId, request);
+
+        assertEquals(2, result.size());
+        assertEquals(interviewId, result.get(0).interviewId());
+        assertEquals("Question 1", result.get(0).description());
+        assertEquals("Question 2", result.get(1).description());
+
+        verify(spyService).getPlaceholdersForInterviewQuestionsPrompt(interviewId);
+        verify(evaluationTypeServ).findAllById(evaluationTypeIds);
+        verify(promptServ).findByPromptCode(InterviewPromptConstants.INTERVIEW_GENERATE_QUESTIONS_PROMPT_CODE);
+        verify(questionServ).prepareQuestionsFromAIResponse(placeholders, evaluationTypes, prompt);
+        verify(questionServ).saveAllQuestions(anyList());
     }
 }

--- a/src/test/java/ma/nttdata/externals/module/interview/service/impl/QuestionServiceImplTest.java
+++ b/src/test/java/ma/nttdata/externals/module/interview/service/impl/QuestionServiceImplTest.java
@@ -1,26 +1,39 @@
 package ma.nttdata.externals.module.interview.service.impl;
 
+import ma.nttdata.externals.commons.constants.InterviewPromptConstants;
+import ma.nttdata.externals.module.candidate.constants.GenderEnum;
 import ma.nttdata.externals.module.candidate.dto.CandidateDTO;
+import ma.nttdata.externals.module.cv.dto.FileDTO;
 import ma.nttdata.externals.module.interview.dto.EvaluationTypeDTO;
 import ma.nttdata.externals.module.interview.dto.placeholdersForInterviewQuestionsPromptDTO;
 import ma.nttdata.externals.module.interview.dto.QuestionDTO;
 import ma.nttdata.externals.module.interview.dto.AIQuestionResponseDTO;
+import ma.nttdata.externals.module.interview.entity.Interview;
+import ma.nttdata.externals.module.interview.entity.Question;
 import ma.nttdata.externals.module.interview.mapper.QuestionMapper;
 import ma.nttdata.externals.module.interview.repository.InterviewRepository;
 import ma.nttdata.externals.module.interview.repository.QuestionRepository;
 import ma.nttdata.externals.module.interview.service.TextToSpeechServ;
 import ma.nttdata.externals.module.offer.dto.OfferDTO;
 import ma.nttdata.externals.module.prompt.dto.PromptDTO;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class QuestionServiceImplTest {
@@ -37,6 +50,15 @@ public class QuestionServiceImplTest {
     private TextToSpeechServ textToSpeechServ;
 
     private QuestionServImpl questionServ;
+
+    @Mock
+    private RestClient.RequestBodySpec requestBodySpec;
+
+    @Mock
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
 
     private boolean mockFlag = true;
 
@@ -76,17 +98,25 @@ public class QuestionServiceImplTest {
              - #Questions And Answers with the estimated answer time and the real answer time: "{QuestionAnswer_DATA}"
             """;
 
+    private QuestionServImpl questionServWithMockFlagTrue;
+    private QuestionServImpl questionServWithMockFlagFalse;
+
+    @BeforeEach
+    void setUp() {
+        questionServWithMockFlagTrue = new QuestionServImpl(
+                questionRepository, questionMapper, interviewRepository, true, aiRestClient, textToSpeechServ
+        );
+
+        questionServWithMockFlagFalse = new QuestionServImpl(
+                questionRepository, questionMapper, interviewRepository, false, aiRestClient, textToSpeechServ
+        );
+    }
+
+
 
 
     @Test
     void PrepareQuestionsFromAIResponse_shouldParseJsonCorrectly() {
-
-        questionServ = new QuestionServImpl(
-                questionRepository,
-                questionMapper,
-                interviewRepository,
-                true,
-                aiRestClient,textToSpeechServ);
         CandidateDTO candidateDTO = new CandidateDTO(UUID.randomUUID(), null, null, 0, null, null, null, null, null, null, null, null, null, null, null);
         OfferDTO offerDTO = new OfferDTO(UUID.randomUUID(), null, null, null,null);
 
@@ -104,7 +134,7 @@ public class QuestionServiceImplTest {
         PromptDTO prompt = new PromptDTO(UUID.randomUUID(),"test",INTERVIEW_EVALUATION_PROMPT,JSON_SCHEMA);
 
 
-        List<QuestionDTO> questions = questionServ.prepareQuestionsFromAIResponse(generateQuestionsInfo, evaluationTypes,prompt);
+        List<QuestionDTO> questions = questionServWithMockFlagTrue.prepareQuestionsFromAIResponse(generateQuestionsInfo, evaluationTypes,prompt);
 
 
         assertNotNull(questions);
@@ -113,51 +143,292 @@ public class QuestionServiceImplTest {
     }
 
     @Test
-    void PrepareQuestionsFromAIResponse_WithMockFlagFalse_shouldParseJsonCorrectly() {
-        questionServ = new QuestionServImpl(
+    void prepareQuestionsFromAIResponse_WithMockFlagTrue_ShouldReturnMockQuestions() throws Exception {
+        CandidateDTO candidate = new CandidateDTO(
+                null,
+                "John Doe",
+                LocalDate.of(1990, 1, 1),
+                5,
+                GenderEnum.M,
+                "Java",
+                "Experienced Java developer",
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                null,
+                List.of(),
+                List.of()
+        );
+        OfferDTO offer = new OfferDTO(
+                null,
+                "Java Developer",
+                "Develop Java backend services",
+                null,
+                List.of()
+        );
+        placeholdersForInterviewQuestionsPromptDTO request = new placeholdersForInterviewQuestionsPromptDTO(
+                candidate, offer, 4, 30
+        );
+
+        List<EvaluationTypeDTO> evaluationTypes = List.of();
+        PromptDTO prompt = new PromptDTO(UUID.randomUUID(),InterviewPromptConstants.INTERVIEW_GENERATE_QUESTIONS_PROMPT_CODE,
+                InterviewPromptConstants.INTERVIEW_QUESTION_GENERATION_PROMPT,InterviewPromptConstants.JSON_SCHEMA);
+
+        List<QuestionDTO> questions = questionServWithMockFlagTrue.prepareQuestionsFromAIResponse(request, evaluationTypes, prompt);
+
+        assertNotNull(questions);
+        assertFalse(questions.isEmpty());
+        assertEquals(15, questions.size());
+        assertEquals("Given your 8 years of experience with Java and Spring Boot, can you walk me through how you would design a microservices architecture for a high-traffic e-commerce platform? Focus on service decomposition and inter-service communication strategies.", questions.get(0).description());
+        assertEquals(5, questions.get(0).durationInMinutes());
+    }
+
+    @Test
+    void prepareQuestionsFromAIResponse_WithMockFlagFalse_ShouldCallGenerateInterviewQuestionsByPrompt() throws Exception {
+
+        CandidateDTO candidate = new CandidateDTO(
+                null,
+                "John Doe",
+                LocalDate.of(1990, 1, 1),
+                5,
+                GenderEnum.M,
+                "Java",
+                "Experienced Java developer",
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                null,
+                List.of(),
+                List.of()
+        );
+        OfferDTO offer = new OfferDTO(
+                null,
+                "Java Developer",
+                "Develop Java backend services",
+                null,
+                List.of()
+        );
+
+        placeholdersForInterviewQuestionsPromptDTO request = new placeholdersForInterviewQuestionsPromptDTO(
+                candidate, offer, 4, 30
+        );
+
+        List<EvaluationTypeDTO> evaluationTypes = List.of();
+        PromptDTO prompt = new PromptDTO(UUID.randomUUID(),InterviewPromptConstants.INTERVIEW_GENERATE_QUESTIONS_PROMPT_CODE,
+                InterviewPromptConstants.INTERVIEW_QUESTION_GENERATION_PROMPT,InterviewPromptConstants.JSON_SCHEMA);
+
+        String fakeJson = """
+            [
+                {"description":"What is Java?","durationInMinutes":"3"},
+                {"description":"Explain REST APIs.","durationInMinutes":"4"}
+            ]
+            """;
+
+        QuestionServImpl spyServ = spy(new QuestionServImpl(
                 questionRepository,
                 questionMapper,
                 interviewRepository,
                 false,
-                aiRestClient,textToSpeechServ);
-        List<AIQuestionResponseDTO> aiResponses = List.of(
-                new AIQuestionResponseDTO("What is Java?", "3"),
-                new AIQuestionResponseDTO("Explain REST APIs.", "4"),
-                new AIQuestionResponseDTO("Describe microservices.", "5"),
-                new AIQuestionResponseDTO("What is Spring Boot?", "6")
+                aiRestClient,
+                textToSpeechServ
+        ));
+
+        doReturn(fakeJson).when(spyServ).generateInterviewQuestionsByPrompt(request, evaluationTypes, prompt);
+
+        List<QuestionDTO> questions = spyServ.prepareQuestionsFromAIResponse(request, evaluationTypes, prompt);
+
+        assertNotNull(questions);
+        assertEquals(2, questions.size());
+        assertEquals("What is Java?", questions.get(0).description());
+        assertEquals(3, questions.get(0).durationInMinutes());
+        assertEquals("Explain REST APIs.", questions.get(1).description());
+        assertEquals(4, questions.get(1).durationInMinutes());
+
+        verify(spyServ).generateInterviewQuestionsByPrompt(request, evaluationTypes, prompt);
+    }
+
+
+    @Test
+    void should_generateInterviewQuestionsByPrompt(){
+        CandidateDTO candidate = new CandidateDTO(
+                UUID.randomUUID(),
+                "John Doe",
+                LocalDate.of(1990, 5, 15),
+                5,
+                GenderEnum.M,
+                "Java",
+                "Experienced Java developer",
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                null,
+                List.of(),
+                List.of()
         );
 
-        List<QuestionDTO> questions = aiResponses.stream()
-                .map(raw -> new QuestionDTO(
-                        null,
-                        raw.description(),
-                        parseDuration(raw.durationInMinutes()),
-                        null,
-                        null
-                ))
-                .toList();
+        OfferDTO offer = new OfferDTO(
+                UUID.randomUUID(),
+                "Java Backend Developer",
+                "We are looking for a skilled Java backend developer",
+                null,
+                List.of()
+        );
 
-        assertEquals(4, questions.size());
+        placeholdersForInterviewQuestionsPromptDTO placeholders = new placeholdersForInterviewQuestionsPromptDTO(
+                candidate,
+                offer,
+                5,
+                60
+        );
+        EvaluationTypeDTO evaluationType1 = new EvaluationTypeDTO(UUID.randomUUID(), "Technical", 1.0);
+        EvaluationTypeDTO evaluationType2 = new EvaluationTypeDTO(UUID.randomUUID(), "Communication", 2.0);
 
-        assertEquals(3, questions.get(0).durationInMinutes());
-        assertEquals(4, questions.get(1).durationInMinutes());
-        assertEquals(5, questions.get(2).durationInMinutes());
-        assertEquals(6, questions.get(3).durationInMinutes());
+        PromptDTO prompt = new PromptDTO(UUID.randomUUID(),
+                InterviewPromptConstants.INTERVIEW_GENERATE_QUESTIONS_PROMPT_CODE,InterviewPromptConstants.INTERVIEW_QUESTION_GENERATION_PROMPT,
+                InterviewPromptConstants.JSON_SCHEMA);
 
+        String expectedResponse = "[{\"description\":\"Explain Java Streams\",\"durationInMinutes\":5}]";
+        when(aiRestClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri("/generateInterviewQuestions")).thenReturn(requestBodySpec);
+        when(requestBodySpec.body(any(String.class))).thenReturn(requestBodySpec);
+        when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(String.class)).thenReturn(expectedResponse);
 
-        assertEquals("What is Java?", questions.get(0).description());
-        assertEquals("Explain REST APIs.", questions.get(1).description());
-        assertEquals("Describe microservices.", questions.get(2).description());
-        assertEquals("What is Spring Boot?", questions.get(3).description());
+        String result = questionServWithMockFlagTrue.generateInterviewQuestionsByPrompt(placeholders,List.of(evaluationType1,evaluationType2),prompt);
+
+        assertEquals(expectedResponse,result);
+
+        verify(aiRestClient).post();
+        verify(requestBodyUriSpec).uri("/generateInterviewQuestions");
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(requestBodySpec).body(bodyCaptor.capture());
+
+        String capturedBody = bodyCaptor.getValue();
+        assertTrue(capturedBody.contains(candidate.toString()));
+        assertTrue(capturedBody.contains(offer.toString()));
+        assertTrue(capturedBody.contains(String.valueOf(placeholders.numberOfQuestions())));
+        assertTrue(capturedBody.contains(String.valueOf(placeholders.estimatedDuration())));
+        assertTrue(capturedBody.contains(List.of(evaluationType1,evaluationType2).toString()));
     }
-    private Integer parseDuration(String durationStr) {
-        if (durationStr == null) return null;
-        try {
-            String digits = durationStr.replaceAll("\\D+", "");
-            return digits.isEmpty() ? null : Integer.parseInt(digits);
-        } catch (NumberFormatException e) {
-            return null;
-        }
+
+    @Test
+    void should_saveAllQuestions(){
+        Interview interview = new Interview();
+        interview.setId(UUID.randomUUID());
+        QuestionDTO questionDTO1 = new QuestionDTO(UUID.randomUUID(), "What is Java?", 5,interview.getId(),null);
+        QuestionDTO questionDTO2 = new QuestionDTO(UUID.randomUUID(), "Explain Streams.", 5,interview.getId(),null);
+        List<QuestionDTO> questionsDTO = List.of(questionDTO1, questionDTO2);
+
+        Question question1 = new Question();
+        question1.setId(UUID.randomUUID());
+        question1.setDescription(questionDTO1.description());
+        question1.setInterview(interview);
+        Question question2 = new Question();
+        question2.setId(UUID.randomUUID());
+        question2.setDescription(questionDTO2.description());
+        question2.setInterview(interview);
+        List<Question> questions = List.of(question1, question2);
+
+        when(questionMapper.toEntity(questionDTO1)).thenReturn(question1);
+        when(questionMapper.toEntity(questionDTO2)).thenReturn(question2);
+        when(questionMapper.toDtoList(anyList())).thenReturn(questionsDTO);
+
+        when(questionRepository.saveAll(questions)).thenReturn(questions);
+
+        List<QuestionDTO> result =questionServWithMockFlagTrue.saveAllQuestions(questionsDTO);
+
+        assertEquals(questionsDTO.size(), result.size());
+        assertEquals(questionsDTO, result);
+
+        verify(questionMapper).toEntity(questionDTO1);
+        verify(questionMapper).toEntity(questionDTO2);
+        verify(questionRepository).saveAll(questions);
+        verify(questionMapper).toDtoList(questions);
+    }
+
+    @Test
+    void should_findAllQuestionsByInterviewId() {
+        UUID interviewId = UUID.randomUUID();
+
+        Question q1 = new Question();
+        q1.setId(UUID.randomUUID());
+        q1.setDescription("What is Java?");
+
+        Question q2 = new Question();
+        q2.setId(UUID.randomUUID());
+        q2.setDescription("Explain Streams.");
+
+        List<Question> questions = List.of(q1, q2);
+
+        when(questionRepository.findByInterviewId(interviewId)).thenReturn(questions);
+
+        List<Question> result = questionServWithMockFlagTrue.findAllQuestionsByInterviewId(interviewId);
+
+        assertEquals(2, result.size());
+        assertEquals(questions, result);
+        verify(questionRepository).findByInterviewId(interviewId);
+    }
+
+    @Test
+    void should_findAllQuestionsDTOSByInterviewId() {
+
+        UUID interviewId = UUID.randomUUID();
+        Interview interview = new Interview();
+        interview.setId(UUID.randomUUID());
+
+        Question q1 = new Question();
+        q1.setId(UUID.randomUUID());
+        q1.setDescription("What is Java?");
+
+        Question q2 = new Question();
+        q2.setId(UUID.randomUUID());
+        q2.setDescription("Explain Streams.");
+
+        List<Question> questions = List.of(q1, q2);
+
+        QuestionDTO qdto1 = new QuestionDTO(q1.getId(), q1.getDescription(), 5,interviewId,null);
+        QuestionDTO qdto2 = new QuestionDTO(q2.getId(), q2.getDescription(), 5,interviewId,null);
+        List<QuestionDTO> dtos = List.of(qdto1, qdto2);
+
+        when(questionRepository.findByInterviewId(interviewId)).thenReturn(questions);
+        when(questionMapper.toDtoList(questions)).thenReturn(dtos);
+
+        List<QuestionDTO> result = questionServWithMockFlagTrue.findAllQuestionsDTOSByInterviewId(interviewId);
+
+        assertEquals(2, result.size());
+        assertEquals(dtos, result);
+        verify(questionRepository).findByInterviewId(interviewId);
+        verify(questionMapper).toDtoList(questions);
+    }
+
+    @Test
+    void should_generateInterviewQuestionAudio() {
+        questionServ = new QuestionServImpl(
+                questionRepository,
+                questionMapper,
+                interviewRepository,
+                true,
+                aiRestClient,textToSpeechServ);
+
+        String text = "What is Java?";
+        byte[] audioBytes = "fake-audio".getBytes();
+
+        when(textToSpeechServ.speak(text)).thenReturn(audioBytes);
+
+        ResponseEntity<byte[]> response = questionServWithMockFlagTrue.generateInterviewQuestionAudio(text);
+
+        assertEquals(audioBytes.length, response.getHeaders().getContentLength());
+        assertEquals(MediaType.valueOf("audio/mpeg"), response.getHeaders().getContentType());
+        assertArrayEquals(audioBytes, response.getBody());
+
+        verify(textToSpeechServ).speak(text);
     }
 
 }

--- a/src/test/java/ma/nttdata/externals/module/interview/service/impl/TextToSpeechServImplTest.java
+++ b/src/test/java/ma/nttdata/externals/module/interview/service/impl/TextToSpeechServImplTest.java
@@ -1,0 +1,93 @@
+package ma.nttdata.externals.module.interview.service.impl;
+
+import ma.nttdata.externals.commons.config.TextToSpeechPropertiesConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.audio.tts.Speech;
+import org.springframework.ai.audio.tts.TextToSpeechPrompt;
+import org.springframework.ai.audio.tts.TextToSpeechResponse;
+import org.springframework.ai.elevenlabs.ElevenLabsTextToSpeechModel;
+import org.springframework.ai.elevenlabs.api.ElevenLabsApi;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class TextToSpeechServImplTest {
+
+    @Mock
+    private TextToSpeechPropertiesConfig propertiesConfig;
+
+    @Mock
+    private ElevenLabsApi elevenLabsApi;
+
+    @Mock
+    private ElevenLabsTextToSpeechModel textToSpeechModel;
+
+    @Mock
+    private TextToSpeechResponse textToSpeechResponse;
+
+    @Mock
+    private Speech speech;
+
+    private TextToSpeechServImpl ttsService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        when(propertiesConfig.getModelId()).thenReturn("model123");
+        when(propertiesConfig.getVoiceId()).thenReturn("voice123");
+        when(propertiesConfig.getStability()).thenReturn(0.5);
+        when(propertiesConfig.getSimilarityBoost()).thenReturn(0.7);
+        when(propertiesConfig.getStyle()).thenReturn(0.4);
+        when(propertiesConfig.isUseSpeakerBoost()).thenReturn(false);
+        when(propertiesConfig.getSpeed()).thenReturn(1.0);
+
+        ttsService = new TextToSpeechServImpl(propertiesConfig, elevenLabsApi);
+    }
+
+    @Test
+    void speak_ShouldReturnAudioBytes_WhenValidTextProvided() {
+        String inputText = "Hello, this is a test message.";
+        byte[] expectedAudioBytes = "mock audio data".getBytes();
+
+        when(propertiesConfig.getModelId()).thenReturn("eleven_multilingual_v2");
+        when(propertiesConfig.getVoiceId()).thenReturn("21m00Tcm4TlvDq8ikWAM");
+        when(propertiesConfig.getStability()).thenReturn(0.5);
+        when(propertiesConfig.getSimilarityBoost()).thenReturn(0.8);
+        when(propertiesConfig.getStyle()).thenReturn(0.0);
+        when(propertiesConfig.isUseSpeakerBoost()).thenReturn(true);
+        when(propertiesConfig.getSpeed()).thenReturn(1.0);
+
+        when(speech.getOutput()).thenReturn(expectedAudioBytes);
+        when(textToSpeechResponse.getResult()).thenReturn(speech);
+
+
+        try (MockedStatic<ElevenLabsTextToSpeechModel> mockedModel = mockStatic(ElevenLabsTextToSpeechModel.class)) {
+            ElevenLabsTextToSpeechModel.Builder mockBuilder = mock(ElevenLabsTextToSpeechModel.Builder.class);
+
+            mockedModel.when(ElevenLabsTextToSpeechModel::builder).thenReturn(mockBuilder);
+            when(mockBuilder.elevenLabsApi(any())).thenReturn(mockBuilder);
+            when(mockBuilder.defaultOptions(any())).thenReturn(mockBuilder);
+            when(mockBuilder.build()).thenReturn(textToSpeechModel);
+
+            when(textToSpeechModel.call(any(TextToSpeechPrompt.class))).thenReturn(textToSpeechResponse);
+
+            byte[] result = ttsService.speak(inputText);
+
+            assertNotNull(result);
+            assertArrayEquals(expectedAudioBytes, result);
+
+            verify(textToSpeechModel).call(any(TextToSpeechPrompt.class));
+            verify(textToSpeechResponse).getResult();
+        }
+    }
+}

--- a/src/test/java/ma/nttdata/externals/module/offer/service/impl/OfferSrvImplTest.java
+++ b/src/test/java/ma/nttdata/externals/module/offer/service/impl/OfferSrvImplTest.java
@@ -1,16 +1,23 @@
 package ma.nttdata.externals.module.offer.service.impl;
 
+import ma.nttdata.externals.commons.constants.OfferFormattedDescriptionPromptConstants;
+import ma.nttdata.externals.module.candidate.constants.LanguageLevel;
+import ma.nttdata.externals.module.candidate.dto.OfferFormattedDescriptionLanguageDTO;
 import ma.nttdata.externals.module.offer.dto.OfferDTO;
+import ma.nttdata.externals.module.offer.dto.OfferFormattedDescriptionDTO;
 import ma.nttdata.externals.module.offer.entity.Offer;
 import ma.nttdata.externals.module.offer.mapper.OfferMapper;
 import ma.nttdata.externals.module.offer.repository.OfferRepository;
+import ma.nttdata.externals.module.prompt.dto.PromptDTO;
 import ma.nttdata.externals.module.prompt.service.PromptService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.*;
 
@@ -26,11 +33,25 @@ class OfferSrvImplTest {
     private OfferMapper offerMapper;
     @Mock
     private RestClient aiRestClient;
+
+    @Mock
+    private RestClient.RequestBodySpec requestBodySpec;
+
+    @Mock
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    @Mock
+    private RestClient.RequestHeadersSpec requestHeadersSpec;
+
     @Mock
     private PromptService promptService;
 
+    private OfferServImpl offerServImplWithMockFlagTrue;
 
-    private OfferServImpl offerServImpl;
+    private OfferServImpl offerServImplWithMockFlagFalse;
 
     private Offer offer;
     private OfferDTO offerDTO;
@@ -53,22 +74,31 @@ class OfferSrvImplTest {
                 null,
                 Collections.emptyList()
         );
-    }
-
-    @Test
-    void testCreateOffer() {
-        offerServImpl = new OfferServImpl(
+        offerServImplWithMockFlagTrue = new OfferServImpl(
                 offerRepository,
                 offerMapper,
                 true,
                 aiRestClient,
                 promptService
         );
+
+        offerServImplWithMockFlagFalse = new OfferServImpl(
+                offerRepository,
+                offerMapper,
+                false,
+                aiRestClient,
+                promptService
+        );
+    }
+
+    @Test
+    void testCreateOffer() {
+
         when(offerMapper.toEntity(offerDTO)).thenReturn(offer);
         when(offerRepository.save(offer)).thenReturn(offer);
         when(offerMapper.toDto(offer)).thenReturn(offerDTO);
 
-        OfferDTO result = offerServImpl.createOffer(offerDTO);
+        OfferDTO result = offerServImplWithMockFlagTrue.createOffer(offerDTO);
 
         assertNotNull(result);
         assertEquals(offerDTO, result);
@@ -77,18 +107,11 @@ class OfferSrvImplTest {
 
     @Test
     void testGetOfferById() {
-        offerServImpl = new OfferServImpl(
-                offerRepository,
-                offerMapper,
-                true,
-                aiRestClient,
-                promptService
-        );
 
         when(offerRepository.findById(offerId)).thenReturn(Optional.of(offer));
         when(offerMapper.toDto(offer)).thenReturn(offerDTO);
 
-        OfferDTO result = offerServImpl.getOfferById(offerId);
+        OfferDTO result = offerServImplWithMockFlagTrue.getOfferById(offerId);
 
         assertNotNull(result);
         assertEquals(offerDTO, result);
@@ -97,13 +120,6 @@ class OfferSrvImplTest {
 
     @Test
     void testGetAllOffers() {
-        offerServImpl = new OfferServImpl(
-                offerRepository,
-                offerMapper,
-                true,
-                aiRestClient,
-                promptService
-        );
 
         List<Offer> offers = Arrays.asList(offer);
         List<OfferDTO> offerDTOs = Arrays.asList(offerDTO);
@@ -111,7 +127,7 @@ class OfferSrvImplTest {
         when(offerRepository.findAll()).thenReturn(offers);
         when(offerMapper.toDtoList(offers)).thenReturn(offerDTOs);
 
-        List<OfferDTO> result = offerServImpl.getAllOffers();
+        List<OfferDTO> result = offerServImplWithMockFlagTrue.getAllOffers();
 
         assertEquals(1, result.size());
         assertEquals(offerDTOs, result);
@@ -120,20 +136,13 @@ class OfferSrvImplTest {
 
     @Test
     void testUpdateOffer() {
-        offerServImpl = new OfferServImpl(
-                offerRepository,
-                offerMapper,
-                true,
-                aiRestClient,
-                promptService
-        );
 
         when(offerRepository.findById(offerId)).thenReturn(Optional.of(offer));
         when(offerMapper.toEntity(offerDTO)).thenReturn(offer);
         when(offerRepository.save(offer)).thenReturn(offer);
         when(offerMapper.toDto(offer)).thenReturn(offerDTO);
 
-        OfferDTO result = offerServImpl.updateOffer(offerId, offerDTO);
+        OfferDTO result = offerServImplWithMockFlagTrue.updateOffer(offerId, offerDTO);
 
         assertNotNull(result);
         assertEquals(offerDTO, result);
@@ -142,18 +151,264 @@ class OfferSrvImplTest {
 
     @Test
     void testDeleteOffer() {
-        offerServImpl = new OfferServImpl(
-                offerRepository,
-                offerMapper,
-                true,
-                aiRestClient,
-                promptService
-        );
 
         when(offerRepository.findById(offerId)).thenReturn(Optional.of(offer));
 
-        offerServImpl.deleteOffer(offerId);
+        offerServImplWithMockFlagTrue.deleteOffer(offerId);
 
         verify(offerRepository, times(1)).delete(offer);
     }
+
+    @Test
+    void should_return_DistinctTitles(){
+
+        List<String> distinctTitles = Arrays.asList("Frontend Developer", "Backend Developer");
+
+        when(offerRepository.findDistinctTitles()).thenReturn(distinctTitles);
+
+        List<String> result = offerServImplWithMockFlagTrue.getDistinctTitles();
+
+        verify(offerRepository, times(1)).findDistinctTitles();
+        assertEquals(distinctTitles, result);
+    }
+
+    @Test
+    void should_getOfferFormattedDescriptionFromAIByPrompt(){
+        PromptDTO prompt = new PromptDTO(UUID.randomUUID(), OfferFormattedDescriptionPromptConstants.OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT_CODE,
+                OfferFormattedDescriptionPromptConstants.OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT,
+                OfferFormattedDescriptionPromptConstants.JSON_SCHEMA);
+
+        String offerDescription = "Looking for a React expert";
+
+        String expectedFormattedDescription = """
+        {
+          "description": "Looking for a React expert",
+          "mainTech": "React - Frontend",
+          "skills": "React - JavaScript",
+          "languages": [{"languageName": "English","level": "ADVANCED"}],
+          "yearsOfExperience": 3,
+          "mainResponsibilities": "Develop UI - Collaborate with team",
+          "education": "Bachelor - Computer Science",
+          "keywords": "React - Frontend - JavaScript"
+        }
+        """;
+
+        when(aiRestClient.post()).thenReturn(requestBodyUriSpec);
+        when(requestBodyUriSpec.uri("/extractOfferFormattedDescription")).thenReturn(requestBodySpec);
+        when(requestBodySpec.body(anyString())).thenReturn(requestBodySpec);
+        when(requestBodySpec.retrieve()).thenReturn(responseSpec);
+        when(responseSpec.body(String.class)).thenReturn(expectedFormattedDescription);
+
+        String result = offerServImplWithMockFlagFalse.getOfferFormattedDescriptionFromAIByPrompt(prompt, offerDescription);
+
+        assertNotNull(result);
+        assertEquals(expectedFormattedDescription, result);
+
+        verify(aiRestClient).post();
+        verify(requestBodyUriSpec).uri("/extractOfferFormattedDescription");
+        verify(requestBodySpec).body(anyString());
+        verify(requestBodySpec).retrieve();
+        verify(responseSpec).body(String.class);
+    }
+
+    @Test
+    void for_Mock_flag_true_prepareFormattedDescriptionByPrompt_should_return_offerFormattedDescription(){
+        PromptDTO prompt = new PromptDTO(UUID.randomUUID(),OfferFormattedDescriptionPromptConstants.OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT_CODE,
+                OfferFormattedDescriptionPromptConstants.OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT,
+                OfferFormattedDescriptionPromptConstants.JSON_SCHEMA);
+
+        when(promptService.findByPromptCode(OfferFormattedDescriptionPromptConstants.OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT_CODE))
+                .thenReturn(prompt);
+
+        OfferFormattedDescriptionDTO mockOfferFormatted = new OfferFormattedDescriptionDTO(
+                "We are seeking a highly skilled Senior Java Developer to join our dynamic fintech team. The role involves designing and implementing scalable microservices, collaborating with cross-functional teams, and ensuring high-quality code standards. The candidate will contribute to architecture decisions, mentor junior developers, and help drive the adoption of best practices.",
+                "Full Stack Javascript",
+                "Java - Spring Boot - Docker - Kubernetes - AWS - MySQL - Git - Agile - Team Leadership - Communication",
+                List.of(
+                        new OfferFormattedDescriptionLanguageDTO("English", LanguageLevel.ADVANCED),
+                        new OfferFormattedDescriptionLanguageDTO("French", LanguageLevel.INTERMEDIATE)
+                ),
+                6,
+                "Design and implement microservices architecture - Optimize application performance - Maintain CI/CD pipelines - Conduct code reviews and mentor junior developers - Collaborate with product managers and QA team - Participate in on-call rotation",
+                "Bachelor in Computer Science - Master in Software Engineering",
+                "Java - Spring Boot - Microservices - Docker - Kubernetes - Fintech - Agile - DevOps - AWS - Backend Development"
+        );
+
+        OfferServImpl spyOfferServ = spy(offerServImplWithMockFlagTrue);
+        doReturn(offerDTO).when(spyOfferServ).getOfferById(offerId);
+        when(offerMapper.mapJsonToDTO( OfferFormattedDescriptionPromptConstants.JSON_MOCK))
+                .thenReturn(mockOfferFormatted);
+        doReturn(1).when(spyOfferServ).setFormattedDescription(eq(offerId),eq(OfferFormattedDescriptionPromptConstants.JSON_MOCK));
+
+
+        OfferFormattedDescriptionDTO   formattedDescription = spyOfferServ
+                .prepareFormattedDescriptionByPrompt(offerId);
+
+        assertNotNull(formattedDescription);
+        assertEquals(mockOfferFormatted, formattedDescription);
+
+        verify(spyOfferServ).getOfferById(offerId);
+        verify(spyOfferServ).setFormattedDescription(eq(offerId), eq(OfferFormattedDescriptionPromptConstants.JSON_MOCK));
+        verify(offerMapper).mapJsonToDTO(OfferFormattedDescriptionPromptConstants.JSON_MOCK);
+
+    }
+
+    @Test
+    void when_mockFlag_false_prepareFormattedDescriptionByPrompt_should_return_realFormattedDescription() {
+        UUID offerId = UUID.randomUUID();
+        PromptDTO prompt = new PromptDTO(UUID.randomUUID(),
+                OfferFormattedDescriptionPromptConstants.OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT_CODE,
+                OfferFormattedDescriptionPromptConstants.OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT,
+                OfferFormattedDescriptionPromptConstants.JSON_SCHEMA);
+
+        OfferFormattedDescriptionDTO aiFormattedDTO = new OfferFormattedDescriptionDTO(
+                "Formatted description from AI",
+                "Full Stack Java",
+                "Java - Spring Boot",
+                List.of(new OfferFormattedDescriptionLanguageDTO("English", LanguageLevel.ADVANCED)),
+                5,
+                "Responsibilities",
+                "Requirements",
+                "Skills"
+        );
+        String aiJsonString = """
+        {
+          "description": "Formatted description from AI",
+          "mainTech": "Full Stack Java",
+          "skills": "Java - Spring Boot",
+          "languages": [
+            {"languageName": "English", "level": "ADVANCED"}
+          ],
+          "yearsOfExperience": 5,
+          "mainResponsibilities": "Responsibilities",
+          "education": "Requirements",
+          "keywords": "Skills"
+        }
+        """;
+
+        OfferServImpl spyOfferServ = spy(offerServImplWithMockFlagFalse);
+
+        when(promptService.findByPromptCode(
+                OfferFormattedDescriptionPromptConstants.OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT_CODE))
+                .thenReturn(prompt);
+        doReturn(offerDTO).when(spyOfferServ).getOfferById(offerId);
+        doReturn(aiJsonString).when(spyOfferServ)
+                .getOfferFormattedDescriptionFromAIByPrompt(prompt, offerDTO.description());
+
+        doReturn(1).when(spyOfferServ).setFormattedDescription(eq(offerId), eq(aiJsonString));
+
+        when(offerMapper.mapJsonToDTO(aiJsonString)).thenReturn(aiFormattedDTO);
+
+        OfferFormattedDescriptionDTO result = spyOfferServ.prepareFormattedDescriptionByPrompt(offerId);
+
+        assertNotNull(result);
+        assertEquals(aiFormattedDTO, result);
+        verify(spyOfferServ).getOfferById(offerId);
+        verify(spyOfferServ).getOfferFormattedDescriptionFromAIByPrompt(prompt, offerDTO.description());
+        verify(spyOfferServ).setFormattedDescription(eq(offerId), eq(aiJsonString));
+        verify(offerMapper).mapJsonToDTO(anyString());
+    }
+
+
+    @Test
+    void when_getOfferById_throws_RuntimeException_then_prepareFormattedDescriptionByPrompt_throws_ResponseStatusException() {
+        UUID offerId = UUID.randomUUID();
+
+        when(promptService.findByPromptCode(OfferFormattedDescriptionPromptConstants.OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT_CODE))
+                .thenReturn(new PromptDTO(
+                        UUID.randomUUID(),
+                        OfferFormattedDescriptionPromptConstants.OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT_CODE,
+                        OfferFormattedDescriptionPromptConstants.OFFER_FORMATTED_DESCRIPTION_EXTRACTION_PROMPT,
+                        OfferFormattedDescriptionPromptConstants.JSON_SCHEMA
+                ));
+
+        OfferServImpl spyOfferServ = spy(offerServImplWithMockFlagTrue);
+
+        doThrow(new RuntimeException("Database error")).when(spyOfferServ).getOfferById(offerId);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> spyOfferServ.prepareFormattedDescriptionByPrompt(offerId));
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertTrue(exception.getMessage().contains("Offer not found with id: " + offerId));
+    }
+
+    @Test
+    void when_offer_exists_getFormattedDescription_should_returnDTO() {
+        OfferServImpl spyOfferServ = spy(offerServImplWithMockFlagTrue);
+
+        OfferFormattedDescriptionDTO expectedDTO = new OfferFormattedDescriptionDTO(
+                "Formatted description from AI",
+                "Full Stack Java",
+                "Java - Spring Boot",
+                List.of(new OfferFormattedDescriptionLanguageDTO("English", LanguageLevel.ADVANCED)),
+                5,
+                "Responsibilities",
+                "Requirements",
+                "Skills"
+        );
+
+        doReturn(offerDTO).when(spyOfferServ).getOfferById(offerId);
+        when(offerMapper.mapJsonToDTO(offerDTO.formattedDescription()))
+                .thenReturn(expectedDTO);
+
+        OfferFormattedDescriptionDTO result = spyOfferServ.getFormattedDescription(offerId);
+
+        assertNotNull(result);
+        assertEquals(expectedDTO, result);
+
+        verify(spyOfferServ).getOfferById(offerId);
+        verify(offerMapper).mapJsonToDTO(offerDTO.formattedDescription());
+    }
+
+    @Test
+    void when_offer_not_found_getFormattedDescription_should_throwResponseStatusException() {
+
+        OfferServImpl spyOfferServ = spy(offerServImplWithMockFlagFalse);
+
+        doThrow(new RuntimeException("not found"))
+                .when(spyOfferServ).getOfferById(any(UUID.class));
+
+        UUID offerId = UUID.randomUUID();
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> spyOfferServ.getFormattedDescription(offerId));
+
+        assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+        assertTrue(exception.getMessage().contains("Offer not found with id"));
+
+        ArgumentCaptor<UUID> captor = ArgumentCaptor.forClass(UUID.class);
+        verify(spyOfferServ).getOfferById(captor.capture());
+        assertEquals(offerId, captor.getValue());
+
+    }
+
+    @Test
+    void when_update_successful_setFormattedDescription_should_returnUpdatedRows() {
+        String formattedDescription = "{\"description\": \"AI formatted\"}";
+
+        when(offerRepository.updateFormattedDescriptionById(offerId, formattedDescription))
+                .thenReturn(1);
+
+        int result = offerServImplWithMockFlagFalse.setFormattedDescription(offerId, formattedDescription);
+
+        assertEquals(1, result);
+        verify(offerRepository).updateFormattedDescriptionById(offerId, formattedDescription);
+    }
+
+    @Test
+    void when_update_fails_setFormattedDescription_should_throwResponseStatusException() {
+        String formattedDescription = "{\"description\": \"AI formatted\"}";
+
+        when(offerRepository.updateFormattedDescriptionById(offerId, formattedDescription))
+                .thenReturn(0);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+                () -> offerServImplWithMockFlagFalse.setFormattedDescription(offerId, formattedDescription));
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, exception.getStatusCode());
+        assertTrue(exception.getMessage().contains("Failed to update formatted description"));
+    }
+
+
 }


### PR DESCRIPTION
Added missing tests for the related taks to interview:

-    OfferService
-    Interviewservice
-    TextToSpeechService
-    QUestionService
-    EvaluationMapper
-    EvaluationTypeMapper

Described the added contoller endpoints in the text to speech task (so they would be clear for other developers)

Corrected some mistakes in some methods in interviewService about the arguments passed to ResourceseNotFoundException class

Added in v2_offers_and _interviews_tables.sql a query that alters the type of the link column ininterviews table to varchar(500).