### PR TITLE
Add API and service to fetch passed candidates for an offer

### DIFF
--- a/src/main/java/ma/nttdata/externals/module/candidate/controller/CandidateController.java
+++ b/src/main/java/ma/nttdata/externals/module/candidate/controller/CandidateController.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import ma.nttdata.externals.commons.exception.BadRequestException;
 import ma.nttdata.externals.commons.exception.ResourceNotFoundException;
 import ma.nttdata.externals.module.candidate.dto.CandidateDTO;
+import ma.nttdata.externals.module.candidate.dto.OfferPassedCandidatesDTO;
 import ma.nttdata.externals.module.candidate.service.CandidateSrv;
 import ma.nttdata.externals.module.offer.dto.OfferCandidatesDTO;
 import ma.nttdata.externals.module.offer.dto.OfferFormattedDescriptionDTO;
@@ -19,7 +20,6 @@ import ma.nttdata.externals.module.offer.service.OfferServ;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import ma.nttdata.externals.module.offer.service.OfferServ;
 
 import java.util.List;
 import java.util.Map;
@@ -291,5 +291,22 @@ public class CandidateController {
 
         return ResponseEntity.ok(recommendedCandidates);
     }
+
+    @GetMapping("/{id}/passed-candidates")
+    @Operation(
+            summary = "Get candidates who passed interviews for an offer",
+            description = "Retrieves the list of candidates that have passed the interviews for a specific job offer, " +
+                    "including their evaluations and scores for each evaluation type."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "List of passed candidates retrieved successfully",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = OfferPassedCandidatesDTO.class))),
+            @ApiResponse(responseCode = "404", description = "Offer not found")
+    })
+    public ResponseEntity<List<OfferPassedCandidatesDTO>> getPassedCandidates(@PathVariable UUID id) {
+        List<OfferPassedCandidatesDTO> candidates = candidateSrv.getPassedCandidatesForOffer(id);
+        return ResponseEntity.ok(candidates);
+    }
+
 
 }

--- a/src/main/java/ma/nttdata/externals/module/candidate/dto/OfferPassedCandidatesDTO.java
+++ b/src/main/java/ma/nttdata/externals/module/candidate/dto/OfferPassedCandidatesDTO.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 public record OfferPassedCandidatesDTO(
         UUID id,
         String fullName,
+        AddressDTO address,
         List<FullEvaluationDTO> evaluations
 ){}
 

--- a/src/main/java/ma/nttdata/externals/module/candidate/dto/OfferPassedCandidatesDTO.java
+++ b/src/main/java/ma/nttdata/externals/module/candidate/dto/OfferPassedCandidatesDTO.java
@@ -1,0 +1,14 @@
+package ma.nttdata.externals.module.candidate.dto;
+
+
+import ma.nttdata.externals.module.interview.dto.FullEvaluationDTO;
+
+import java.util.List;
+import java.util.UUID;
+
+public record OfferPassedCandidatesDTO(
+        UUID id,
+        String fullName,
+        List<FullEvaluationDTO> evaluations
+){}
+

--- a/src/main/java/ma/nttdata/externals/module/candidate/service/CandidateSrv.java
+++ b/src/main/java/ma/nttdata/externals/module/candidate/service/CandidateSrv.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import ma.nttdata.externals.module.candidate.dto.CandidateDTO;
+import ma.nttdata.externals.module.candidate.dto.OfferPassedCandidatesDTO;
 import ma.nttdata.externals.module.offer.dto.OfferCandidatesDTO;
 import ma.nttdata.externals.module.offer.dto.OfferFormattedDescriptionDTO;
 
@@ -23,6 +24,9 @@ public interface CandidateSrv {
     Long getTotalCandidates();
     List<String> getDistinctMainTechs();
     List<OfferCandidatesDTO> findRecommendedCandidates(OfferFormattedDescriptionDTO offer);
+
+    List<OfferPassedCandidatesDTO> getPassedCandidatesForOffer(UUID offerID);
+
 
 
 }

--- a/src/main/java/ma/nttdata/externals/module/candidate/service/impl/CandidateSrvImpl.java
+++ b/src/main/java/ma/nttdata/externals/module/candidate/service/impl/CandidateSrvImpl.java
@@ -307,7 +307,7 @@ public class CandidateSrvImpl implements CandidateSrv {
                                 })
                                 .toList();
 
-                        return new OfferPassedCandidatesDTO(candidateDTO.id(), candidateDTO.fullName(), fullEvaluations);
+                        return new OfferPassedCandidatesDTO(candidateDTO.id(), candidateDTO.fullName(),candidateDTO.address(), fullEvaluations);
                     })
                     .toList();
 

--- a/src/main/java/ma/nttdata/externals/module/candidate/service/impl/CandidateSrvImpl.java
+++ b/src/main/java/ma/nttdata/externals/module/candidate/service/impl/CandidateSrvImpl.java
@@ -7,6 +7,7 @@ import ma.nttdata.externals.commons.exception.InternalServerException;
 import ma.nttdata.externals.commons.exception.ResourceNotFoundException;
 import ma.nttdata.externals.module.candidate.constants.LanguageLevel;
 import ma.nttdata.externals.module.candidate.dto.CandidateDTO;
+import ma.nttdata.externals.module.candidate.dto.OfferPassedCandidatesDTO;
 import ma.nttdata.externals.module.candidate.entity.*;
 import ma.nttdata.externals.module.candidate.mapper.CandidateMapper;
 import ma.nttdata.externals.module.candidate.repository.CandidateRepository;
@@ -14,9 +15,21 @@ import ma.nttdata.externals.module.candidate.repository.CityRepository;
 import ma.nttdata.externals.module.candidate.repository.CountryRepository;
 import ma.nttdata.externals.module.candidate.repository.LanguageRepository;
 import ma.nttdata.externals.module.candidate.service.CandidateSrv;
+import ma.nttdata.externals.module.interview.dto.EvaluationDTO;
+import ma.nttdata.externals.module.interview.dto.EvaluationTypeDTO;
+import ma.nttdata.externals.module.interview.dto.FullEvaluationDTO;
+import ma.nttdata.externals.module.interview.dto.InterviewDTO;
+import ma.nttdata.externals.module.interview.mapper.EvaluationMapper;
+import ma.nttdata.externals.module.interview.service.EvaluationServ;
+import ma.nttdata.externals.module.interview.service.EvaluationTypeServ;
+import ma.nttdata.externals.module.interview.service.InterviewServ;
 import ma.nttdata.externals.module.offer.dto.OfferCandidatesDTO;
+import ma.nttdata.externals.module.offer.dto.OfferDTO;
 import ma.nttdata.externals.module.offer.dto.OfferFormattedDescriptionDTO;
+import ma.nttdata.externals.module.offer.service.OfferServ;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -28,17 +41,27 @@ public class CandidateSrvImpl implements CandidateSrv {
     private final CountryRepository countryRepository;
     private final CityRepository cityRepository;
     private final LanguageRepository languageRepository;
+    private final OfferServ offerServ;
+    private final InterviewServ interviewServ;
+    private final EvaluationServ evaluationServ;
+    private final EvaluationTypeServ evaluationTypeServ;
+    private final EvaluationMapper evaluationMapper;
 
     public CandidateSrvImpl(CandidateMapper candidateMapper,
                             CandidateRepository candidateRepository,
                             CountryRepository countryRepository,
                             CityRepository cityRepository,
-                            LanguageRepository languageRepository) {
+                            LanguageRepository languageRepository, OfferServ offerServ, InterviewServ interviewServ, EvaluationServ evaluationServ, EvaluationTypeServ evaluationTypeServ, EvaluationMapper evaluationMapper) {
         this.mapper = candidateMapper;
         this.candidateRepository = candidateRepository;
         this.countryRepository = countryRepository;
         this.cityRepository = cityRepository;
         this.languageRepository = languageRepository;
+        this.offerServ = offerServ;
+        this.interviewServ = interviewServ;
+        this.evaluationServ = evaluationServ;
+        this.evaluationTypeServ = evaluationTypeServ;
+        this.evaluationMapper = evaluationMapper;
     }
 
     @Override
@@ -258,5 +281,40 @@ public class CandidateSrvImpl implements CandidateSrv {
         // relies on the enum order (BEGINNER < INTERMEDIATE < ADVANCED < NATIVE)
         return candidateLevel.ordinal() >= offerLevel.ordinal();
     }
+
+    public List<OfferPassedCandidatesDTO> getPassedCandidatesForOffer(UUID offerId) {
+        try {
+            OfferDTO offer = offerServ.getOfferById(offerId);
+
+            List<InterviewDTO> interviews = interviewServ.getInterviewsByOfferId(offerId);
+
+            return interviews.stream()
+                    .map(interview -> {
+                        CandidateDTO candidateDTO = getById(interview.candidateId());
+
+                        List<FullEvaluationDTO> fullEvaluations = evaluationServ
+                                .getAllEvaluationsByInterviewID(interview.id()).stream()
+                                .map(evaluationMapper::toDto)
+                                .map(evaluation -> {
+                                    EvaluationTypeDTO type = evaluationTypeServ.getTypeById(evaluation.evaluationTypeId());
+                                    return new FullEvaluationDTO(
+                                            evaluation.id(),
+                                            evaluation.score(),
+                                            evaluation.feedback(),
+                                            evaluation.interviewId(),
+                                            type
+                                    );
+                                })
+                                .toList();
+
+                        return new OfferPassedCandidatesDTO(candidateDTO.id(), candidateDTO.fullName(), fullEvaluations);
+                    })
+                    .toList();
+
+        } catch (RuntimeException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Offer not found with id: " + offerId, e);
+        }
+    }
+
 
 }

--- a/src/test/java/ma/nttdata/externals/module/candidate/controller/CandidateControllerTest.java
+++ b/src/test/java/ma/nttdata/externals/module/candidate/controller/CandidateControllerTest.java
@@ -3,6 +3,8 @@ package ma.nttdata.externals.module.candidate.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import ma.nttdata.externals.module.candidate.constants.GenderEnum;
 import ma.nttdata.externals.module.candidate.dto.*;
+import ma.nttdata.externals.module.interview.dto.EvaluationTypeDTO;
+import ma.nttdata.externals.module.interview.dto.FullEvaluationDTO;
 import ma.nttdata.externals.module.interview.dto.InterviewDTO;
 import ma.nttdata.externals.module.candidate.service.CandidateSrv;
 import ma.nttdata.externals.module.offer.service.OfferServ;
@@ -443,4 +445,57 @@ class CandidateControllerTest {
 
         verify(candidateSrv).getCandidates();
     }
+
+    @Test
+    @WithMockUser
+    void testGetPassedCandidatesForOffer() throws Exception {
+        // Arrange
+        UUID offerId = UUID.randomUUID();
+        UUID candidateId1 = UUID.randomUUID();
+        UUID candidateId2 = UUID.randomUUID();
+        UUID evaluationTypeId = UUID.randomUUID();
+
+        // Create dummy evaluations
+        FullEvaluationDTO eval1 = new FullEvaluationDTO(
+                UUID.randomUUID(), 85.0, "Good", UUID.randomUUID(),
+                new EvaluationTypeDTO(evaluationTypeId, "overAll",3.0)
+        );
+
+        FullEvaluationDTO eval2 = new FullEvaluationDTO(
+                UUID.randomUUID(), 90.0, "Excellent", UUID.randomUUID(),
+                new EvaluationTypeDTO(evaluationTypeId, "communication",3.0)
+        );
+
+        // Create dummy candidates
+        OfferPassedCandidatesDTO candidate1 = new OfferPassedCandidatesDTO(
+                candidateId1, "John Doe", List.of(eval1, eval2)
+        );
+
+        OfferPassedCandidatesDTO candidate2 = new OfferPassedCandidatesDTO(
+                candidateId2, "Jane Smith", Collections.emptyList() // candidate with no evaluations
+        );
+
+        List<OfferPassedCandidatesDTO> passedCandidates = List.of(candidate1, candidate2);
+
+        // Mock the service
+        when(candidateSrv.getPassedCandidatesForOffer(eq(offerId))).thenReturn(passedCandidates);
+
+        // Act & Assert
+        mockMvc.perform(get(API_URL + "/{id}/passed-candidates", offerId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].id").value(candidateId1.toString()))
+                .andExpect(jsonPath("$[0].fullName").value("John Doe"))
+                .andExpect(jsonPath("$[0].evaluations", hasSize(2)))
+                .andExpect(jsonPath("$[0].evaluations[0].score").value(85.0))
+                .andExpect(jsonPath("$[0].evaluations[0].evaluationType.description").value("overAll"))
+                .andExpect(jsonPath("$[1].id").value(candidateId2.toString()))
+                .andExpect(jsonPath("$[1].fullName").value("Jane Smith"))
+                .andExpect(jsonPath("$[1].evaluations", hasSize(0)));
+
+        // Verify that the service method was called once
+        verify(candidateSrv, times(1)).getPassedCandidatesForOffer(eq(offerId));
+    }
+
 }

--- a/src/test/java/ma/nttdata/externals/module/candidate/controller/CandidateControllerTest.java
+++ b/src/test/java/ma/nttdata/externals/module/candidate/controller/CandidateControllerTest.java
@@ -468,11 +468,11 @@ class CandidateControllerTest {
 
         // Create dummy candidates
         OfferPassedCandidatesDTO candidate1 = new OfferPassedCandidatesDTO(
-                candidateId1, "John Doe", List.of(eval1, eval2)
+                candidateId1, "John Doe",null, List.of(eval1, eval2)
         );
 
         OfferPassedCandidatesDTO candidate2 = new OfferPassedCandidatesDTO(
-                candidateId2, "Jane Smith", Collections.emptyList() // candidate with no evaluations
+                candidateId2, "Jane Smith",null, Collections.emptyList() // candidate with no evaluations
         );
 
         List<OfferPassedCandidatesDTO> passedCandidates = List.of(candidate1, candidate2);

--- a/src/test/java/ma/nttdata/externals/module/candidate/service/impl/CandidateSrvImplTest.java
+++ b/src/test/java/ma/nttdata/externals/module/candidate/service/impl/CandidateSrvImplTest.java
@@ -351,8 +351,8 @@ class CandidateSrvImplTest {
         // Mock Interview - IMPORTANT: use candidateId from setUp()
         InterviewDTO interview = new InterviewDTO(
                 interviewId, null, null, null, null, null,
-                null, null, 0, 0, candidateId, offerId,
-                Collections.emptyList(), Collections.emptyList()
+                null, 0, 0, offerId, candidateId, new ArrayList<>(),
+                new ArrayList<>(),""
         );
         when(interviewServ.getInterviewsByOfferId(offerId))
                 .thenReturn(Collections.singletonList(interview));

--- a/src/test/java/ma/nttdata/externals/module/candidate/service/impl/CandidateSrvImplTest.java
+++ b/src/test/java/ma/nttdata/externals/module/candidate/service/impl/CandidateSrvImplTest.java
@@ -3,12 +3,26 @@ package ma.nttdata.externals.module.candidate.service.impl;
 import jakarta.persistence.EntityNotFoundException;
 import ma.nttdata.externals.module.candidate.constants.GenderEnum;
 import ma.nttdata.externals.module.candidate.dto.CandidateDTO;
+import ma.nttdata.externals.module.candidate.dto.OfferPassedCandidatesDTO;
 import ma.nttdata.externals.module.candidate.entity.*;
 import ma.nttdata.externals.module.candidate.mapper.CandidateMapper;
 import ma.nttdata.externals.module.candidate.repository.CandidateRepository;
 import ma.nttdata.externals.module.candidate.repository.CityRepository;
 import ma.nttdata.externals.module.candidate.repository.CountryRepository;
 import ma.nttdata.externals.module.candidate.repository.LanguageRepository;
+import ma.nttdata.externals.module.interview.dto.EvaluationDTO;
+import ma.nttdata.externals.module.interview.dto.EvaluationTypeDTO;
+import ma.nttdata.externals.module.interview.dto.InterviewDTO;
+import ma.nttdata.externals.module.interview.entity.Evaluation;
+import ma.nttdata.externals.module.interview.entity.EvaluationType;
+import ma.nttdata.externals.module.interview.entity.Interview;
+import ma.nttdata.externals.module.interview.mapper.EvaluationMapper;
+import ma.nttdata.externals.module.interview.mapper.InterviewMapper;
+import ma.nttdata.externals.module.interview.service.impl.EvaluationServImpl;
+import ma.nttdata.externals.module.interview.service.impl.EvaluationTypeServImpl;
+import ma.nttdata.externals.module.interview.service.impl.InterviewServImpl;
+import ma.nttdata.externals.module.offer.dto.OfferDTO;
+import ma.nttdata.externals.module.offer.service.impl.OfferServImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +35,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,6 +43,9 @@ class CandidateSrvImplTest {
 
     @Mock
     private CandidateMapper candidateMapper;
+
+    @Mock
+    private EvaluationMapper evaluationMapper;
 
     @Mock
     private CandidateRepository candidateRepository;
@@ -41,7 +59,19 @@ class CandidateSrvImplTest {
     @Mock
     private LanguageRepository languageRepository;
 
-    @InjectMocks
+    @Mock
+    private OfferServImpl offerServ;
+
+    @Mock
+    private InterviewServImpl interviewServ;
+
+    @Mock
+    private EvaluationServImpl evaluationServ;
+
+    @Mock
+    private EvaluationTypeServImpl evaluationTypeServ;
+
+    // Don't use @InjectMocks - we'll manually inject
     private CandidateSrvImpl candidateSrv;
 
     private Candidate candidate;
@@ -50,6 +80,21 @@ class CandidateSrvImplTest {
 
     @BeforeEach
     void setUp() {
+        // Manually create the instance - adjust constructor parameters based on CandidateSrvImpl
+        // This ensures all mocks are properly injected
+        candidateSrv = new CandidateSrvImpl(
+                candidateMapper,
+                candidateRepository,
+                countryRepository,
+                cityRepository,
+                languageRepository,
+                offerServ,
+                interviewServ,
+                evaluationServ,
+                evaluationTypeServ,
+                evaluationMapper
+        );
+
         candidateId = UUID.randomUUID();
 
         // Create a candidate entity
@@ -240,7 +285,7 @@ class CandidateSrvImplTest {
         List<Object[]> languageResults = new ArrayList<>();
         Object[] englishResult = new Object[] {"English", 1L};
         languageResults.add(englishResult);
-        
+
         when(languageRepository.countCandidatesByLanguage()).thenReturn(languageResults);
 
         // Execute
@@ -279,5 +324,93 @@ class CandidateSrvImplTest {
 
         // Verify
         assertEquals(5L, result);
+    }
+
+    @Test
+    void testGetPassedCandidatesForOffer() {
+        // Debug: verify mocks are not null
+        assertNotNull(offerServ, "offerServ mock should not be null");
+        assertNotNull(interviewServ, "interviewServ mock should not be null");
+        assertNotNull(evaluationServ, "evaluationServ mock should not be null");
+
+        // Setup - use the candidateId from setUp()
+        UUID offerId = UUID.randomUUID();
+        UUID interviewId = UUID.randomUUID();
+        UUID evaluationTypeId = UUID.randomUUID();
+
+        // Mock OfferDTO - correct constructor with 5 parameters
+        OfferDTO offerDTO = new OfferDTO(
+                offerId,
+                "Test Offer",
+                "Test Description",
+                null,
+                Collections.emptyList()
+        );
+        when(offerServ.getOfferById(offerId)).thenReturn(offerDTO);
+
+        // Mock Interview - IMPORTANT: use candidateId from setUp()
+        InterviewDTO interview = new InterviewDTO(
+                interviewId, null, null, null, null, null,
+                null, null, 0, 0, candidateId, offerId,
+                Collections.emptyList(), Collections.emptyList()
+        );
+        when(interviewServ.getInterviewsByOfferId(offerId))
+                .thenReturn(Collections.singletonList(interview));
+
+        // Mock the repository to return the candidate entity
+        when(candidateRepository.findById(candidateId)).thenReturn(Optional.of(candidate));
+        when(candidateMapper.candidateToCandidateDTO(candidate)).thenReturn(candidateDTO);
+
+        // Mock Evaluation entity
+        EvaluationType evaluationType = new EvaluationType();
+        evaluationType.setId(evaluationTypeId);
+        evaluationType.setDescription("Technical");
+
+        Evaluation evaluation = new Evaluation();
+        evaluation.setId(UUID.randomUUID());
+        evaluation.setScore(95.0);
+        evaluation.setFeedback("Excellent");
+        Interview mockInterview = new Interview();
+        mockInterview.setId(interviewId);
+        evaluation.setInterview(mockInterview);
+        evaluation.setEvaluationType(evaluationType);
+
+        when(evaluationServ.getAllEvaluationsByInterviewID(interviewId))
+                .thenReturn(Collections.singletonList(evaluation));
+
+        // Mock mapper
+        EvaluationDTO evaluationDTO = new EvaluationDTO(
+                evaluation.getId(),
+                evaluation.getScore(),
+                evaluation.getFeedback(),
+                interviewId,
+                evaluationTypeId
+        );
+        when(evaluationMapper.toDto(evaluation)).thenReturn(evaluationDTO);
+
+        // Mock EvaluationType service
+        EvaluationTypeDTO evaluationTypeDTO = new EvaluationTypeDTO(evaluationTypeId, "Technical", 3.0);
+        when(evaluationTypeServ.getTypeById(evaluationTypeId)).thenReturn(evaluationTypeDTO);
+
+        // Execute
+        List<OfferPassedCandidatesDTO> result = candidateSrv.getPassedCandidatesForOffer(offerId);
+
+        // Verify
+        assertNotNull(result);
+        assertEquals(1, result.size());
+
+        OfferPassedCandidatesDTO candidateResult = result.get(0);
+        assertEquals(candidateId, candidateResult.id());
+        assertEquals(candidateDTO.fullName(), candidateResult.fullName());
+        assertEquals(1, candidateResult.evaluations().size());
+        assertEquals("Technical", candidateResult.evaluations().get(0).evaluationType().description());
+
+        // Verify mocks were called
+        verify(offerServ).getOfferById(offerId);
+        verify(interviewServ).getInterviewsByOfferId(offerId);
+        verify(candidateRepository).findById(candidateId);
+        verify(evaluationServ).getAllEvaluationsByInterviewID(interviewId);
+        verify(evaluationMapper).toDto(evaluation);
+        verify(evaluationTypeServ).getTypeById(evaluationTypeId);
     }
 }


### PR DESCRIPTION
This PR introduces functionality to retrieve candidates who passed interviews for a specific job offer. 

Changes include:
- Created `OfferPassedCandidatesDTO` to represent candidates with their evaluations.
- Added a new endpoint `/offers/{id}/passed-candidates` in `CandidateController`.
- Implemented `getPassedCandidatesForOffer` in `CandidateSrv` and `CandidateSrvImpl`.
- Updated tests for the new endpoint and service method.

This allows the frontend to fetch and display passed candidates along with their evaluation scores.
